### PR TITLE
Add helper function for API tests

### DIFF
--- a/api_tests/main_test.go
+++ b/api_tests/main_test.go
@@ -1,10 +1,21 @@
 package api_tests
 
 import (
+	"context"
+	"fmt"
 	"log"
+	"os"
+	"os/exec"
 	"testing"
 
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/rshelekhov/jwtauth"
+	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	"github.com/rshelekhov/sso/api_tests/suite"
+	"github.com/rshelekhov/sso/internal/lib/interceptor/appid"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
 type Config struct {
@@ -51,4 +62,81 @@ func MustLoadPath(configPath string) *Config {
 	}
 
 	return &cfg
+}
+
+type adminUser struct {
+	email       string
+	password    string
+	accessToken string
+	userID      string
+}
+
+func registerAndLoginAdmin(t *testing.T, st *suite.Suite, ctx context.Context) (*adminUser, func()) {
+	// Register admin user via CLI
+	adminEmail := gofakeit.Email()
+	adminPass := randomFakePassword()
+
+	err := registerAdmin(t, cfg.AppID, adminEmail, adminPass)
+	require.NoError(t, err)
+
+	// Login as admin
+	md := metadata.Pairs(appid.Header, cfg.AppID)
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	respLogin, err := st.AuthClient.Login(ctx, &ssov1.LoginRequest{
+		Email:    adminEmail,
+		Password: adminPass,
+		UserDeviceData: &ssov1.UserDeviceData{
+			UserAgent: gofakeit.UserAgent(),
+			Ip:        gofakeit.IPv4Address(),
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, respLogin.GetTokenData())
+
+	admin := &adminUser{
+		email:       adminEmail,
+		password:    adminPass,
+		accessToken: respLogin.GetTokenData().GetAccessToken(),
+	}
+
+	// Get admin's ID
+	md.Append(jwtauth.AuthorizationHeader, admin.accessToken)
+	respUser, err := st.AuthClient.GetUser(ctx, &ssov1.GetUserRequest{})
+	require.NoError(t, err)
+
+	admin.userID = respUser.GetUser().GetId()
+
+	cleanup := func() {
+		md = metadata.Pairs(appid.Header, cfg.AppID)
+		md.Append(jwtauth.AuthorizationHeader, admin.accessToken)
+		cleanCtx := metadata.NewOutgoingContext(ctx, md)
+
+		_, err = st.AuthClient.DeleteUser(cleanCtx, &ssov1.DeleteUserRequest{})
+		require.NoError(t, err)
+	}
+
+	return admin, cleanup
+}
+
+func registerAdmin(t *testing.T, appID, email, password string) error {
+	cliPath := "../cmd/register_admin/main.go"
+	if _, err := os.Stat(cliPath); os.IsNotExist(err) {
+		return fmt.Errorf("register_admin CLI not found at %s", cliPath)
+	}
+
+	cmd := exec.Command("go", "run", cliPath,
+		"-app-id", appID,
+		"-email", email,
+		"-password", password)
+
+	cmd.Env = append(os.Environ(), "CONFIG_PATH=../config/.env")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("Failed to register admin: %s", output)
+		return fmt.Errorf("failed to register admin: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
implement admin user registration and login functionality in tests, including CLI integration for admin registration and user cleanup

(cherry picked from commit 7de84cb7c018ba1a63772c03108725beafa97dc2)