### PR TITLE
Refactor gRPC API: Update Protos

### DIFF
--- a/api_tests/delete_user_test.go
+++ b/api_tests/delete_user_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/rshelekhov/jwtauth"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
 	"github.com/stretchr/testify/require"
@@ -26,11 +27,11 @@ func TestDeleteUser_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -50,7 +51,7 @@ func TestDeleteUser_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Delete user
-	_, err = st.AuthClient.DeleteUser(ctx, &ssov1.DeleteUserRequest{})
+	_, err = st.UserService.DeleteUser(ctx, &userv1.DeleteUserRequest{})
 	require.NoError(t, err)
 }
 
@@ -66,11 +67,11 @@ func TestDeleteUserByID_HappyPath(t *testing.T) {
 	md := metadata.Pairs(clientid.Header, cfg.ClientID)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -86,12 +87,12 @@ func TestDeleteUserByID_HappyPath(t *testing.T) {
 	md.Append(jwtauth.AuthorizationHeader, accessToken)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	respUser, err := st.AuthClient.GetUser(ctx, &ssov1.GetUserRequest{})
+	respUser, err := st.UserService.GetUser(ctx, &userv1.GetUserRequest{})
 	require.NoError(t, err)
 	userID := respUser.GetUser().GetId()
 
 	// Delete user by ID
-	_, err = st.AuthClient.DeleteUserByID(ctx, &ssov1.DeleteUserByIDRequest{
+	_, err = st.UserService.DeleteUserByID(ctx, &userv1.DeleteUserByIDRequest{
 		UserId: userID,
 	})
 	require.NoError(t, err)

--- a/api_tests/get_jwks_test.go
+++ b/api_tests/get_jwks_test.go
@@ -3,7 +3,7 @@ package api_tests
 import (
 	"testing"
 
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
 	"github.com/stretchr/testify/require"
@@ -17,7 +17,7 @@ func TestGetJWKS_HappyPath(t *testing.T) {
 	md := metadata.Pairs(clientid.Header, cfg.ClientID)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	resp, err := st.AuthClient.GetJWKS(ctx, &ssov1.GetJWKSRequest{})
+	resp, err := st.AuthService.GetJWKS(ctx, &authv1.GetJWKSRequest{})
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.GetJwks())
 	require.NotEmpty(t, resp.GetJwks()[0])

--- a/api_tests/get_user_test.go
+++ b/api_tests/get_user_test.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/rshelekhov/jwtauth"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
 	"github.com/stretchr/testify/require"
@@ -28,11 +29,11 @@ func TestGetUser_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -53,7 +54,7 @@ func TestGetUser_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Get user
-	respGet, err := st.AuthClient.GetUser(ctx, &ssov1.GetUserRequest{})
+	respGet, err := st.UserService.GetUser(ctx, &userv1.GetUserRequest{})
 	require.NoError(t, err)
 	require.NotEmpty(t, respGet.User.GetEmail())
 	require.NotEmpty(t, respGet.User.GetUpdatedAt())
@@ -80,11 +81,11 @@ func TestGetUserByID_HappyPath(t *testing.T) {
 	md := metadata.Pairs(clientid.Header, cfg.ClientID)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -100,12 +101,12 @@ func TestGetUserByID_HappyPath(t *testing.T) {
 	md.Append(jwtauth.AuthorizationHeader, accessToken)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	respUser, err := st.AuthClient.GetUser(ctx, &ssov1.GetUserRequest{})
+	respUser, err := st.UserService.GetUser(ctx, &userv1.GetUserRequest{})
 	require.NoError(t, err)
 	userID := respUser.GetUser().GetId()
 
 	// Get user's data by ID
-	respGet, err := st.AuthClient.GetUserByID(ctx, &ssov1.GetUserByIDRequest{
+	respGet, err := st.UserService.GetUserByID(ctx, &userv1.GetUserByIDRequest{
 		UserId: userID,
 	})
 	require.NoError(t, err)
@@ -137,11 +138,11 @@ func TestGetUser_UserNotFound(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -162,11 +163,11 @@ func TestGetUser_UserNotFound(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Delete user
-	_, err = st.AuthClient.DeleteUser(ctx, &ssov1.DeleteUserRequest{})
+	_, err = st.UserService.DeleteUser(ctx, &userv1.DeleteUserRequest{})
 	require.NoError(t, err)
 
 	// Try to get user
-	respGet, err := st.AuthClient.GetUser(ctx, &ssov1.GetUserRequest{})
+	respGet, err := st.UserService.GetUser(ctx, &userv1.GetUserRequest{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), domain.ErrUserNotFound.Error())
 	require.Empty(t, respGet)
@@ -184,11 +185,11 @@ func TestGetUserByID_UserNotFound(t *testing.T) {
 	md := metadata.Pairs(clientid.Header, cfg.ClientID)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -204,16 +205,16 @@ func TestGetUserByID_UserNotFound(t *testing.T) {
 	md.Append(jwtauth.AuthorizationHeader, accessToken)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	respUser, err := st.AuthClient.GetUser(ctx, &ssov1.GetUserRequest{})
+	respUser, err := st.UserService.GetUser(ctx, &userv1.GetUserRequest{})
 	require.NoError(t, err)
 	userID := respUser.GetUser().GetId()
 
 	// Delete user
-	_, err = st.AuthClient.DeleteUser(ctx, &ssov1.DeleteUserRequest{})
+	_, err = st.UserService.DeleteUser(ctx, &userv1.DeleteUserRequest{})
 	require.NoError(t, err)
 
 	// Try to get user's data by ID after deletion
-	respGet, err := st.AuthClient.GetUserByID(ctx, &ssov1.GetUserByIDRequest{
+	respGet, err := st.UserService.GetUserByID(ctx, &userv1.GetUserByIDRequest{
 		UserId: userID,
 	})
 	require.Error(t, err)

--- a/api_tests/helpers.go
+++ b/api_tests/helpers.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/rshelekhov/jwtauth"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ type cleanupParams struct {
 	t        *testing.T
 	st       *suite.Suite
 	clientID string
-	token    *ssov1.TokenData
+	token    *authv1.TokenData
 }
 
 func cleanup(params cleanupParams, clientID string) {
@@ -38,6 +39,6 @@ func cleanup(params cleanupParams, clientID string) {
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 
 	// Delete user
-	_, err := params.st.AuthClient.DeleteUser(ctx, &ssov1.DeleteUserRequest{})
+	_, err := params.st.UserService.DeleteUser(ctx, &userv1.DeleteUserRequest{})
 	require.NoError(params.t, err)
 }

--- a/api_tests/login_test.go
+++ b/api_tests/login_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/golang-jwt/jwt/v5"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/controller/grpc"
 	"github.com/rshelekhov/sso/internal/domain"
@@ -34,11 +34,11 @@ func TestLogin_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -47,10 +47,10 @@ func TestLogin_HappyPath(t *testing.T) {
 	require.NotEmpty(t, respReg.GetTokenData())
 
 	// Login user
-	respLogin, err := st.AuthClient.Login(ctx, &ssov1.LoginRequest{
+	respLogin, err := st.AuthService.Login(ctx, &authv1.LoginRequest{
 		Email:    email,
 		Password: pass,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -61,7 +61,7 @@ func TestLogin_HappyPath(t *testing.T) {
 	require.NotEmpty(t, token)
 
 	// Get JWKS
-	jwks, err := st.AuthClient.GetJWKS(ctx, &ssov1.GetJWKSRequest{})
+	jwks, err := st.AuthService.GetJWKS(ctx, &authv1.GetJWKSRequest{})
 	require.NoError(t, err)
 	require.NotEmpty(t, jwks.GetJwks())
 
@@ -121,7 +121,7 @@ func TestLogin_HappyPath(t *testing.T) {
 	cleanup(params, cfg.ClientID)
 }
 
-func getJWKByKid(jwks []*ssov1.JWK, kid string) (*ssov1.JWK, error) {
+func getJWKByKid(jwks []*authv1.JWK, kid string) (*authv1.JWK, error) {
 	for _, jwk := range jwks {
 		if jwk.GetKid() == kid {
 			return jwk, nil
@@ -144,11 +144,11 @@ func TestLogin_FailCases(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -235,10 +235,10 @@ func TestLogin_FailCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Login user
-			_, err := st.AuthClient.Login(ctx, &ssov1.LoginRequest{
+			_, err := st.AuthService.Login(ctx, &authv1.LoginRequest{
 				Email:    tt.email,
 				Password: tt.password,
-				UserDeviceData: &ssov1.UserDeviceData{
+				UserDeviceData: &authv1.UserDeviceData{
 					UserAgent: tt.userAgent,
 					Ip:        tt.ip,
 				},

--- a/api_tests/logout_test.go
+++ b/api_tests/logout_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/rshelekhov/jwtauth"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
 	"github.com/stretchr/testify/require"
@@ -26,11 +26,11 @@ func TestLogout_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -51,8 +51,8 @@ func TestLogout_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Logout user
-	_, err = st.AuthClient.Logout(ctx, &ssov1.LogoutRequest{
-		UserDeviceData: &ssov1.UserDeviceData{
+	_, err = st.AuthService.Logout(ctx, &authv1.LogoutRequest{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},

--- a/api_tests/refresh_test.go
+++ b/api_tests/refresh_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/brianvoe/gofakeit/v6"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/controller/grpc"
 	"github.com/rshelekhov/sso/internal/domain"
@@ -28,11 +28,11 @@ func TestRefresh_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -47,9 +47,9 @@ func TestRefresh_HappyPath(t *testing.T) {
 	require.NotEmpty(t, refreshToken)
 
 	// Refresh tokens
-	respRefresh, err := st.AuthClient.Refresh(ctx, &ssov1.RefreshRequest{
+	respRefresh, err := st.AuthService.RefreshTokens(ctx, &authv1.RefreshTokensRequest{
 		RefreshToken: refreshToken,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -81,11 +81,11 @@ func TestRefresh_FailCases(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -142,9 +142,9 @@ func TestRefresh_FailCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Refresh tokens
-			_, err = st.AuthClient.Refresh(ctx, &ssov1.RefreshRequest{
+			_, err = st.AuthService.RefreshTokens(ctx, &authv1.RefreshTokensRequest{
 				RefreshToken: tt.refreshToken,
-				UserDeviceData: &ssov1.UserDeviceData{
+				UserDeviceData: &authv1.UserDeviceData{
 					UserAgent: tt.userAgent,
 					Ip:        tt.ip,
 				},
@@ -178,11 +178,11 @@ func TestRefresh_DeviceNotFound(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -196,9 +196,9 @@ func TestRefresh_DeviceNotFound(t *testing.T) {
 	require.NotEmpty(t, refreshToken)
 
 	// Refresh tokens
-	_, err = st.AuthClient.Refresh(ctx, &ssov1.RefreshRequest{
+	_, err = st.AuthService.RefreshTokens(ctx, &authv1.RefreshTokensRequest{
 		RefreshToken: refreshToken,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: gofakeit.UserAgent(),
 			Ip:        ip,
 		},

--- a/api_tests/register_client_test.go
+++ b/api_tests/register_client_test.go
@@ -6,37 +6,37 @@ import (
 	"github.com/rshelekhov/sso/internal/domain"
 
 	"github.com/brianvoe/gofakeit/v6"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	clientv1 "github.com/rshelekhov/sso-protos/gen/go/api/client/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegisterApp_HappyPath(t *testing.T) {
+func TestRegisterClient_HappyPath(t *testing.T) {
 	ctx, st := suite.New(t)
 
-	appName := gofakeit.Word()
+	clientName := gofakeit.Word()
 
 	// Register app
-	_, err := st.AuthClient.RegisterApp(ctx, &ssov1.RegisterAppRequest{
-		AppName: appName,
+	_, err := st.ClientManagementService.RegisterClient(ctx, &clientv1.RegisterClientRequest{
+		ClientName: clientName,
 	})
 	require.NoError(t, err)
 }
 
-func TestRegisterApp_AppAlreadyExists(t *testing.T) {
+func TestRegisterClient_ClientAlreadyExists(t *testing.T) {
 	ctx, st := suite.New(t)
 
-	appName := gofakeit.Word()
+	clientName := gofakeit.Word()
 
 	// Register app
-	_, err := st.AuthClient.RegisterApp(ctx, &ssov1.RegisterAppRequest{
-		AppName: appName,
+	_, err := st.ClientManagementService.RegisterClient(ctx, &clientv1.RegisterClientRequest{
+		ClientName: clientName,
 	})
 	require.NoError(t, err)
 
 	// Register app again
-	_, err = st.AuthClient.RegisterApp(ctx, &ssov1.RegisterAppRequest{
-		AppName: appName,
+	_, err = st.ClientManagementService.RegisterClient(ctx, &clientv1.RegisterClientRequest{
+		ClientName: clientName,
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), domain.ErrClientAlreadyExists.Error())

--- a/api_tests/request_id_test.go
+++ b/api_tests/request_id_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/rshelekhov/jwtauth"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/requestid"
@@ -30,11 +30,11 @@ func TestRequestID_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -54,8 +54,8 @@ func TestRequestID_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Logout user
-	_, err = st.AuthClient.Logout(ctx, &ssov1.LogoutRequest{
-		UserDeviceData: &ssov1.UserDeviceData{
+	_, err = st.AuthService.Logout(ctx, &authv1.LogoutRequest{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -89,11 +89,11 @@ func TestRequestID_EmptyRequestID(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -114,8 +114,8 @@ func TestRequestID_EmptyRequestID(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Logout user
-	_, err = st.AuthClient.Logout(ctx, &ssov1.LogoutRequest{
-		UserDeviceData: &ssov1.UserDeviceData{
+	_, err = st.AuthService.Logout(ctx, &authv1.LogoutRequest{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},

--- a/api_tests/reset_password_test.go
+++ b/api_tests/reset_password_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/controller/grpc"
 	"github.com/rshelekhov/sso/internal/domain"
@@ -29,11 +29,11 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -41,7 +41,7 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Request reset password instructions on email
-	_, err = st.AuthClient.ResetPassword(ctx, &ssov1.ResetPasswordRequest{
+	_, err = st.AuthService.ResetPassword(ctx, &authv1.ResetPasswordRequest{
 		Email:      email,
 		ConfirmUrl: cfg.ConfirmChangePasswordURL,
 	})
@@ -52,7 +52,7 @@ func TestResetPassword_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Change password
-	_, err = st.AuthClient.ChangePassword(ctx, &ssov1.ChangePasswordRequest{
+	_, err = st.AuthService.ChangePassword(ctx, &authv1.ChangePasswordRequest{
 		Token:           resetPasswordToken,
 		UpdatedPassword: randomFakePassword(),
 	})
@@ -85,11 +85,11 @@ func TestResetPassword_TokenExpired(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -97,7 +97,7 @@ func TestResetPassword_TokenExpired(t *testing.T) {
 	require.NoError(t, err)
 
 	// Request reset password instructions on email
-	_, err = st.AuthClient.ResetPassword(ctx, &ssov1.ResetPasswordRequest{
+	_, err = st.AuthService.ResetPassword(ctx, &authv1.ResetPasswordRequest{
 		Email:      email,
 		ConfirmUrl: cfg.ConfirmChangePasswordURL,
 	})
@@ -112,7 +112,7 @@ func TestResetPassword_TokenExpired(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to change password
-	_, err = st.AuthClient.ChangePassword(ctx, &ssov1.ChangePasswordRequest{
+	_, err = st.AuthService.ChangePassword(ctx, &authv1.ChangePasswordRequest{
 		Token:           resetPasswordToken,
 		UpdatedPassword: randomFakePassword(),
 	})
@@ -150,11 +150,11 @@ func TestResetPassword_EmptyEmail(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -162,7 +162,7 @@ func TestResetPassword_EmptyEmail(t *testing.T) {
 	require.NoError(t, err)
 
 	// Request reset password instructions on email
-	_, err = st.AuthClient.ResetPassword(ctx, &ssov1.ResetPasswordRequest{
+	_, err = st.AuthService.ResetPassword(ctx, &authv1.ResetPasswordRequest{
 		Email:      emptyValue,
 		ConfirmUrl: cfg.ConfirmChangePasswordURL,
 	})
@@ -195,11 +195,11 @@ func TestResetPassword_FailCasesWithPassword(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -226,7 +226,7 @@ func TestResetPassword_FailCasesWithPassword(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Request reset password instructions on email
-			_, err = st.AuthClient.ResetPassword(ctx, &ssov1.ResetPasswordRequest{
+			_, err = st.AuthService.ResetPassword(ctx, &authv1.ResetPasswordRequest{
 				Email:      email,
 				ConfirmUrl: cfg.ConfirmChangePasswordURL,
 			})
@@ -237,7 +237,7 @@ func TestResetPassword_FailCasesWithPassword(t *testing.T) {
 			require.NoError(t, err)
 
 			// Change password
-			_, err = st.AuthClient.ChangePassword(ctx, &ssov1.ChangePasswordRequest{
+			_, err = st.AuthService.ChangePassword(ctx, &authv1.ChangePasswordRequest{
 				Token:           resetPasswordToken,
 				UpdatedPassword: tt.password,
 			})

--- a/api_tests/suite/suite.go
+++ b/api_tests/suite/suite.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"testing"
 
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	clientv1 "github.com/rshelekhov/sso-protos/gen/go/api/client/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	testStorage "github.com/rshelekhov/sso/api_tests/suite/storage"
 	"github.com/rshelekhov/sso/internal/config"
 	"github.com/rshelekhov/sso/internal/config/settings"
@@ -18,9 +20,11 @@ import (
 
 type Suite struct {
 	*testing.T
-	Cfg        *config.ServerSettings
-	AuthClient ssov1.AuthClient
-	Storage    testStorage.TestStorage
+	Cfg                     *config.ServerSettings
+	AuthService             authv1.AuthServiceClient
+	UserService             userv1.UserServiceClient
+	ClientManagementService clientv1.ClientManagementServiceClient
+	Storage                 testStorage.TestStorage
 }
 
 const (
@@ -60,10 +64,12 @@ func New(t *testing.T) (context.Context, *Suite) {
 	}
 
 	return ctx, &Suite{
-		T:          t,
-		Cfg:        cfg,
-		AuthClient: ssov1.NewAuthClient(cc),
-		Storage:    testStorage,
+		T:                       t,
+		Cfg:                     cfg,
+		AuthService:             authv1.NewAuthServiceClient(cc),
+		UserService:             userv1.NewUserServiceClient(cc),
+		ClientManagementService: clientv1.NewClientManagementServiceClient(cc),
+		Storage:                 testStorage,
 	}
 }
 

--- a/api_tests/update_user_test.go
+++ b/api_tests/update_user_test.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/rshelekhov/jwtauth"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/domain"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
@@ -27,11 +28,11 @@ func TestUpdateUser_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -53,7 +54,7 @@ func TestUpdateUser_HappyPath(t *testing.T) {
 	updatedEmail := gofakeit.Email()
 
 	// Update user
-	resp, err := st.AuthClient.UpdateUser(ctx, &ssov1.UpdateUserRequest{
+	resp, err := st.UserService.UpdateUser(ctx, &userv1.UpdateUserRequest{
 		Email:           updatedEmail,
 		CurrentPassword: pass,
 		UpdatedPassword: randomFakePassword(),
@@ -87,11 +88,11 @@ func TestUpdateUser_EmailAlreadyTaken(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user for taking email
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           emailTaken,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -102,11 +103,11 @@ func TestUpdateUser_EmailAlreadyTaken(t *testing.T) {
 	require.NotEmpty(t, token1)
 
 	// Register user
-	resp2Reg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	resp2Reg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -126,7 +127,7 @@ func TestUpdateUser_EmailAlreadyTaken(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Update user
-	_, err = st.AuthClient.UpdateUser(ctx, &ssov1.UpdateUserRequest{
+	_, err = st.UserService.UpdateUser(ctx, &userv1.UpdateUserRequest{
 		Email:           emailTaken,
 		CurrentPassword: pass,
 		UpdatedPassword: randomFakePassword(),
@@ -135,7 +136,7 @@ func TestUpdateUser_EmailAlreadyTaken(t *testing.T) {
 	require.Contains(t, err.Error(), domain.ErrEmailAlreadyTaken.Error())
 
 	// Cleanup database after test
-	tokens := []*ssov1.TokenData{token1, token2}
+	tokens := []*authv1.TokenData{token1, token2}
 	for _, token := range tokens {
 		params := cleanupParams{
 			t:        t,
@@ -209,11 +210,11 @@ func TestUpdateUser_FailCases(t *testing.T) {
 			}
 
 			// Register user
-			respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+			respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 				Email:           tt.regEmail,
 				Password:        pass,
 				VerificationUrl: cfg.VerificationURL,
-				UserDeviceData: &ssov1.UserDeviceData{
+				UserDeviceData: &authv1.UserDeviceData{
 					UserAgent: userAgent,
 					Ip:        ip,
 				},
@@ -233,7 +234,7 @@ func TestUpdateUser_FailCases(t *testing.T) {
 			ctx = metadata.NewOutgoingContext(ctx, md)
 
 			// Update user
-			_, err = st.AuthClient.UpdateUser(ctx, &ssov1.UpdateUserRequest{
+			_, err = st.UserService.UpdateUser(ctx, &userv1.UpdateUserRequest{
 				Email:           tt.updEmail,
 				CurrentPassword: tt.curPassword,
 				UpdatedPassword: tt.updPassword,

--- a/api_tests/verify_email_test.go
+++ b/api_tests/verify_email_test.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/rshelekhov/jwtauth"
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/api_tests/suite"
 	"github.com/rshelekhov/sso/internal/domain/entity"
 	"github.com/rshelekhov/sso/internal/lib/interceptor/clientid"
@@ -28,11 +29,11 @@ func TestVerifyEmail_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -44,7 +45,7 @@ func TestVerifyEmail_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify email
-	_, err = st.AuthClient.VerifyEmail(ctx, &ssov1.VerifyEmailRequest{
+	_, err = st.AuthService.VerifyEmail(ctx, &authv1.VerifyEmailRequest{
 		Token: verificationToken,
 	})
 	require.NoError(t, err)
@@ -63,7 +64,7 @@ func TestVerifyEmail_HappyPath(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Get user data to check if email was verified
-	respGet, err := st.AuthClient.GetUser(ctx, &ssov1.GetUserRequest{})
+	respGet, err := st.UserService.GetUser(ctx, &userv1.GetUserRequest{})
 	require.NoError(t, err)
 	require.NotEmpty(t, respGet.User.GetVerified())
 	require.True(t, respGet.User.GetVerified())
@@ -92,11 +93,11 @@ func TestVerifyEmail_TokenExpired(t *testing.T) {
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	// Register user
-	respReg, err := st.AuthClient.RegisterUser(ctx, &ssov1.RegisterUserRequest{
+	respReg, err := st.AuthService.RegisterUser(ctx, &authv1.RegisterUserRequest{
 		Email:           email,
 		Password:        pass,
 		VerificationUrl: cfg.VerificationURL,
-		UserDeviceData: &ssov1.UserDeviceData{
+		UserDeviceData: &authv1.UserDeviceData{
 			UserAgent: userAgent,
 			Ip:        ip,
 		},
@@ -112,7 +113,7 @@ func TestVerifyEmail_TokenExpired(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to verify email (a new email with verification token should be sent)
-	_, err = st.AuthClient.VerifyEmail(ctx, &ssov1.VerifyEmailRequest{
+	_, err = st.AuthService.VerifyEmail(ctx, &authv1.VerifyEmailRequest{
 		Token: verificationToken,
 	})
 	require.Error(t, err)

--- a/go.mod
+++ b/go.mod
@@ -14,17 +14,18 @@ require (
 	github.com/mailgun/mailgun-go/v4 v4.12.0
 	github.com/redis/go-redis/v9 v9.7.1
 	github.com/rshelekhov/jwtauth v0.1.14
-	github.com/rshelekhov/sso-protos v0.1.10
+	github.com/rshelekhov/sso-protos v0.3.3
 	github.com/segmentio/ksuid v1.0.4
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.10.0
 	go.mongodb.org/mongo-driver v1.17.1
 	golang.org/x/crypto v0.33.0
 	google.golang.org/grpc v1.70.0
-	google.golang.org/protobuf v1.36.5
+	google.golang.org/protobuf v1.36.6
 )
 
 require (
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1 h1:AUL6VF5YWL01j/1H/DQbPUSDkEwYqwVCNw7yhbpOxSQ=
+buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250613105001-9f2d3c737feb.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
@@ -136,6 +138,12 @@ github.com/rshelekhov/jwtauth v0.1.14 h1:aq2iJcW1uVYKbg5IpzXqBzYfNQxRPLqnHZcw1Mk
 github.com/rshelekhov/jwtauth v0.1.14/go.mod h1:juQqrzOFeaEgL2+ieSep4ysq9Zc8xZ7vx129nWH0fiI=
 github.com/rshelekhov/sso-protos v0.1.10 h1:M1JkXiPtuQJz352Hp+5+E3bnWHSW3J7HO66iax6ai5U=
 github.com/rshelekhov/sso-protos v0.1.10/go.mod h1:ddXC0QBZDm80KHweZ6IRZw1Wi8xhz6bk+qtrx4b3uxQ=
+github.com/rshelekhov/sso-protos v0.3.1 h1:o/sKLaC50GgjxiWJ5jO4DQzzGY9d0QCYySC8zay51dU=
+github.com/rshelekhov/sso-protos v0.3.1/go.mod h1:ddXC0QBZDm80KHweZ6IRZw1Wi8xhz6bk+qtrx4b3uxQ=
+github.com/rshelekhov/sso-protos v0.3.2 h1:am9QXMYh87HUZoH4hw3dxV7eMOD7MSdn6vazlxGeEbo=
+github.com/rshelekhov/sso-protos v0.3.2/go.mod h1:ddXC0QBZDm80KHweZ6IRZw1Wi8xhz6bk+qtrx4b3uxQ=
+github.com/rshelekhov/sso-protos v0.3.3 h1:dcZmXKoSKmkmCwHxMk6F1d81javAzmh7/cqReENi1EM=
+github.com/rshelekhov/sso-protos v0.3.3/go.mod h1:+1CtdHjjBbGQOuMRoL/SFZErCHcuBe8dwfFIsu5n/2A=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
@@ -238,6 +246,8 @@ google.golang.org/grpc v1.70.0 h1:pWFv03aZoHzlRKHWicjsZytKAiYCtNS0dHbXnIdq7jQ=
 google.golang.org/grpc v1.70.0/go.mod h1:ofIJqVKDXx/JiXrwr2IG4/zwdH9txy3IlF40RmcJSQw=
 google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/config/method_config.go
+++ b/internal/config/method_config.go
@@ -50,89 +50,81 @@ func (mc *GRPCMethodsConfig) GetAppIDRequiredMethods() []string {
 func initGRPCMethodSettings() map[string]GRPCMethodSettings {
 	configs := map[string]GRPCMethodSettings{
 		// Auth methods
-		"/auth.Auth/RegisterUser": {
+		"/api.auth.v1.AuthService/RegisterUser": {
 			RequireJWT:      false,
 			RequireClientID: true,
 			SkipUserID:      true,
 		},
-		"/auth.Auth/Login": {
+		"/api.auth.v1.AuthService/Login": {
 			RequireJWT:      false,
 			RequireClientID: true,
 			SkipUserID:      true,
 		},
-		"/auth.Auth/VerifyEmail": {
+		"/api.auth.v1.AuthService/VerifyEmail": {
 			RequireJWT:      false,
 			RequireClientID: false,
 			SkipUserID:      true,
 		},
-		"/auth.Auth/ResetPassword": {
+		"/api.auth.v1.AuthService/ResetPassword": {
 			RequireJWT:      false,
 			RequireClientID: true,
 			SkipUserID:      true,
 		},
-		"/auth.Auth/ChangePassword": {
+		"/api.auth.v1.AuthService/ChangePassword": {
 			RequireJWT:      false,
 			RequireClientID: true,
 			SkipUserID:      true,
 		},
-		"/auth.Auth/RegisterApp": {
-			RequireJWT:      false,
-			RequireClientID: false,
-			SkipUserID:      true,
-		},
-		"/auth.Auth/GetJWKS": {
+		"/api.auth.v1.AuthService/GetJWKS": {
 			RequireJWT:      false,
 			RequireClientID: true,
 			SkipUserID:      true,
 		},
-		"/auth.Auth/Refresh": {
+		"/api.auth.v1.AuthService/RefreshTokens": {
 			RequireJWT:      false,
 			RequireClientID: true,
 			SkipUserID:      true,
 		},
 
 		// User methods
-		"/auth.Auth/GetUser": {
+		"/api.user.v1.UserService/GetUser": {
 			RequireJWT:      true,
 			RequireClientID: true,
 			SkipUserID:      false,
 		},
-		"/auth.Auth/UpdateUser": {
+		"/api.user.v1.UserService/UpdateUser": {
 			RequireJWT:      true,
 			RequireClientID: true,
 			SkipUserID:      false,
 		},
-		"/auth.Auth/DeleteUser": {
+		"/api.user.v1.UserService/DeleteUser": {
 			RequireJWT:      true,
 			RequireClientID: true,
 			SkipUserID:      false,
 		},
-		"/auth.Auth/Logout": {
+		"/api.auth.v1.AuthService/Logout": {
 			RequireJWT:      true,
 			RequireClientID: true,
 			SkipUserID:      false,
 		},
 
 		// Admin methods
-		"/auth.Auth/GetUserByID": {
+		"/api.user.v1.UserService/GetUserByID": {
 			RequireJWT:      true,
 			RequireClientID: true,
 			SkipUserID:      false,
 		},
-		"/auth.Auth/DeleteUserByID": {
+		"/api.user.v1.UserService/DeleteUserByID": {
 			RequireJWT:      true,
 			RequireClientID: true,
 			SkipUserID:      false,
 		},
-		"/auth.Auth/ChangeUserRole": {
-			RequireJWT:      true,
-			RequireClientID: true,
-			SkipUserID:      false,
-		},
-		"/auth.Auth/GetUserRole": {
-			RequireJWT:      true,
-			RequireClientID: true,
-			SkipUserID:      false,
+
+		// Client methods
+		"/api.client.v1.ClientManagementService/RegisterClient": {
+			RequireJWT:      false,
+			RequireClientID: false,
+			SkipUserID:      true,
 		},
 	}
 

--- a/internal/controller/grpc/auth.go
+++ b/internal/controller/grpc/auth.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"log/slog"
 
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"github.com/rshelekhov/sso/internal/controller"
-
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
 	"github.com/rshelekhov/sso/internal/domain"
 	"github.com/rshelekhov/sso/internal/lib/e"
 )
 
-func (c *gRPCController) Login(ctx context.Context, req *ssov1.LoginRequest) (*ssov1.LoginResponse, error) {
+func (c *gRPCController) Login(ctx context.Context, req *authv1.LoginRequest) (*authv1.LoginResponse, error) {
 	const method = "controller.gRPC.Login"
 
 	log := c.log.With(slog.String("method", method))
@@ -47,7 +46,7 @@ func (c *gRPCController) Login(ctx context.Context, req *ssov1.LoginRequest) (*s
 	return toLoginResponse(tokenData), nil
 }
 
-func (c *gRPCController) RegisterUser(ctx context.Context, req *ssov1.RegisterUserRequest) (*ssov1.RegisterUserResponse, error) {
+func (c *gRPCController) RegisterUser(ctx context.Context, req *authv1.RegisterUserRequest) (*authv1.RegisterUserResponse, error) {
 	const method = "controller.gRPC.RegisterUser"
 
 	log := c.log.With(slog.String("method", method))
@@ -83,7 +82,7 @@ func (c *gRPCController) RegisterUser(ctx context.Context, req *ssov1.RegisterUs
 	return toRegisterUserResponse(tokenData), nil
 }
 
-func (c *gRPCController) VerifyEmail(ctx context.Context, req *ssov1.VerifyEmailRequest) (*ssov1.VerifyEmailResponse, error) {
+func (c *gRPCController) VerifyEmail(ctx context.Context, req *authv1.VerifyEmailRequest) (*authv1.VerifyEmailResponse, error) {
 	const method = "controller.gRPC.VerifyEmail"
 
 	log := c.log.With(slog.String("method", method))
@@ -113,10 +112,10 @@ func (c *gRPCController) VerifyEmail(ctx context.Context, req *ssov1.VerifyEmail
 		return nil, mapErrorToGRPCStatus(domain.ErrTokenExpiredWithEmailResent)
 	}
 
-	return &ssov1.VerifyEmailResponse{}, nil
+	return &authv1.VerifyEmailResponse{}, nil
 }
 
-func (c *gRPCController) ResetPassword(ctx context.Context, req *ssov1.ResetPasswordRequest) (*ssov1.ResetPasswordResponse, error) {
+func (c *gRPCController) ResetPassword(ctx context.Context, req *authv1.ResetPasswordRequest) (*authv1.ResetPasswordResponse, error) {
 	const method = "controller.gRPC.ResetPassword"
 
 	log := c.log.With(slog.String("method", method))
@@ -149,10 +148,10 @@ func (c *gRPCController) ResetPassword(ctx context.Context, req *ssov1.ResetPass
 		return nil, mapErrorToGRPCStatus(err)
 	}
 
-	return &ssov1.ResetPasswordResponse{}, nil
+	return &authv1.ResetPasswordResponse{}, nil
 }
 
-func (c *gRPCController) ChangePassword(ctx context.Context, req *ssov1.ChangePasswordRequest) (*ssov1.ChangePasswordResponse, error) {
+func (c *gRPCController) ChangePassword(ctx context.Context, req *authv1.ChangePasswordRequest) (*authv1.ChangePasswordResponse, error) {
 	const method = "controller.gRPC.ChangePassword"
 
 	log := c.log.With(slog.String("method", method))
@@ -188,10 +187,10 @@ func (c *gRPCController) ChangePassword(ctx context.Context, req *ssov1.ChangePa
 		return nil, mapErrorToGRPCStatus(domain.ErrTokenExpiredWithEmailResent)
 	}
 
-	return &ssov1.ChangePasswordResponse{}, nil
+	return &authv1.ChangePasswordResponse{}, nil
 }
 
-func (c *gRPCController) Logout(ctx context.Context, req *ssov1.LogoutRequest) (*ssov1.LogoutResponse, error) {
+func (c *gRPCController) Logout(ctx context.Context, req *authv1.LogoutRequest) (*authv1.LogoutResponse, error) {
 	const method = "controller.gRPC.Logout"
 
 	log := c.log.With(slog.String("method", method))
@@ -223,11 +222,11 @@ func (c *gRPCController) Logout(ctx context.Context, req *ssov1.LogoutRequest) (
 		return nil, mapErrorToGRPCStatus(err)
 	}
 
-	return &ssov1.LogoutResponse{}, nil
+	return &authv1.LogoutResponse{}, nil
 }
 
-func (c *gRPCController) Refresh(ctx context.Context, req *ssov1.RefreshRequest) (*ssov1.RefreshResponse, error) {
-	const method = "controller.gRPC.Refresh"
+func (c *gRPCController) RefreshTokens(ctx context.Context, req *authv1.RefreshTokensRequest) (*authv1.RefreshTokensResponse, error) {
+	const method = "controller.gRPC.RefreshTokens"
 
 	log := c.log.With(slog.String("method", method))
 
@@ -257,10 +256,10 @@ func (c *gRPCController) Refresh(ctx context.Context, req *ssov1.RefreshRequest)
 		e.LogError(ctx, log, controller.ErrFailedToRefreshTokens, err)
 		return nil, mapErrorToGRPCStatus(err)
 	}
-	return toRefreshResponse(tokenData), nil
+	return toRefreshTokensResponse(tokenData), nil
 }
 
-func (c *gRPCController) GetJWKS(ctx context.Context, req *ssov1.GetJWKSRequest) (*ssov1.GetJWKSResponse, error) {
+func (c *gRPCController) GetJWKS(ctx context.Context, req *authv1.GetJWKSRequest) (*authv1.GetJWKSResponse, error) {
 	const method = "controller.gRPC.GetJWKS"
 
 	log := c.log.With(slog.String("method", method))

--- a/internal/controller/grpc/client.go
+++ b/internal/controller/grpc/client.go
@@ -8,11 +8,11 @@ import (
 	"github.com/rshelekhov/sso/internal/controller"
 	"github.com/rshelekhov/sso/internal/lib/e"
 
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	clientv1 "github.com/rshelekhov/sso-protos/gen/go/api/client/v1"
 )
 
-func (c *gRPCController) RegisterApp(ctx context.Context, req *ssov1.RegisterAppRequest) (*ssov1.RegisterAppResponse, error) {
-	const method = "controller.gRPC.RegisterApp"
+func (c *gRPCController) RegisterClient(ctx context.Context, req *clientv1.RegisterClientRequest) (*clientv1.RegisterClientResponse, error) {
+	const method = "controller.gRPC.RegisterClient"
 
 	log := c.log.With(slog.String("method", method))
 
@@ -24,18 +24,17 @@ func (c *gRPCController) RegisterApp(ctx context.Context, req *ssov1.RegisterApp
 
 	log = log.With(slog.String("requestID", reqID))
 
-	if err = validateRegisterAppRequest(req); err != nil {
+	if err = validateRegisterClientRequest(req); err != nil {
 		e.LogError(ctx, log, controller.ErrValidationError, err)
 		return nil, mapErrorToGRPCStatus(fmt.Errorf("%w: %w", controller.ErrValidationError, err))
 	}
 
-	// TODO: change to GetClientName after updating imports of sso-protos
-	clientName := req.GetAppName()
+	clientName := req.GetClientName()
 
 	err = c.clientUsecase.RegisterClient(ctx, clientName)
 	if err != nil {
 		return nil, mapErrorToGRPCStatus(err)
 	}
 
-	return &ssov1.RegisterAppResponse{}, nil
+	return &clientv1.RegisterClientResponse{}, nil
 }

--- a/internal/controller/grpc/controller.go
+++ b/internal/controller/grpc/controller.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"log/slog"
 
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	clientv1 "github.com/rshelekhov/sso-protos/gen/go/api/client/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/internal/domain/entity"
 	"github.com/rshelekhov/sso/internal/domain/service/clientvalidator"
 	"google.golang.org/grpc"
 )
 
 type gRPCController struct {
-	ssov1.UnimplementedAuthServer
+	authv1.UnimplementedAuthServiceServer
+	userv1.UnimplementedUserServiceServer
+	clientv1.UnimplementedClientManagementServiceServer
 	log             *slog.Logger
 	clientValidator clientvalidator.Validator
 	clientUsecase   ClientUsecase
@@ -53,11 +57,15 @@ func RegisterController(
 	authUsecase AuthUsecase,
 	userUsecase UserUsecase,
 ) {
-	ssov1.RegisterAuthServer(gRPC, &gRPCController{
+	controller := &gRPCController{
 		log:             log,
 		clientValidator: clientValidator,
 		clientUsecase:   clientUsecase,
 		authUsecase:     authUsecase,
 		userUsecase:     userUsecase,
-	})
+	}
+
+	authv1.RegisterAuthServiceServer(gRPC, controller)
+	userv1.RegisterUserServiceServer(gRPC, controller)
+	clientv1.RegisterClientManagementServiceServer(gRPC, controller)
 }

--- a/internal/controller/grpc/helpers.go
+++ b/internal/controller/grpc/helpers.go
@@ -21,19 +21,19 @@ func (c *gRPCController) getRequestID(ctx context.Context) (string, error) {
 }
 
 func (c *gRPCController) getAndValidateClientID(ctx context.Context) (string, error) {
-	clientID, err := c.getAppID(ctx)
+	clientID, err := c.getClientID(ctx)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", controller.ErrFailedToGetClientID, err)
 	}
 
-	if err = c.validateAppID(ctx, clientID); err != nil {
+	if err = c.validateClientID(ctx, clientID); err != nil {
 		return "", fmt.Errorf("%w: %w", controller.ErrFailedToValidateClientID, err)
 	}
 
 	return clientID, nil
 }
 
-func (c *gRPCController) getAppID(ctx context.Context) (string, error) {
+func (c *gRPCController) getClientID(ctx context.Context) (string, error) {
 	clientID, ok := clientid.FromContext(ctx)
 	if !ok {
 		return "", controller.ErrClientIDNotFoundInContext
@@ -42,7 +42,7 @@ func (c *gRPCController) getAppID(ctx context.Context) (string, error) {
 	return clientID, nil
 }
 
-func (c *gRPCController) validateAppID(ctx context.Context, clientID string) error {
+func (c *gRPCController) validateClientID(ctx context.Context, clientID string) error {
 	if err := c.clientValidator.ValidateClientID(ctx, clientID); err != nil {
 		if errors.Is(err, domain.ErrClientNotFound) {
 			return controller.ErrClientNotFound

--- a/internal/controller/grpc/mapper.go
+++ b/internal/controller/grpc/mapper.go
@@ -5,7 +5,8 @@ import (
 
 	"github.com/rshelekhov/sso/internal/controller"
 
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/internal/domain"
 	"github.com/rshelekhov/sso/internal/domain/entity"
 	"google.golang.org/grpc/codes"
@@ -13,7 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func fromLoginRequest(req *ssov1.LoginRequest) *entity.UserRequestData {
+func fromLoginRequest(req *authv1.LoginRequest) *entity.UserRequestData {
 	return &entity.UserRequestData{
 		Email:    req.GetEmail(),
 		Password: req.GetPassword(),
@@ -24,9 +25,9 @@ func fromLoginRequest(req *ssov1.LoginRequest) *entity.UserRequestData {
 	}
 }
 
-func toLoginResponse(tokenData entity.SessionTokens) *ssov1.LoginResponse {
-	return &ssov1.LoginResponse{
-		TokenData: &ssov1.TokenData{
+func toLoginResponse(tokenData entity.SessionTokens) *authv1.LoginResponse {
+	return &authv1.LoginResponse{
+		TokenData: &authv1.TokenData{
 			AccessToken:      tokenData.AccessToken,
 			RefreshToken:     tokenData.RefreshToken,
 			Domain:           tokenData.Domain,
@@ -38,7 +39,7 @@ func toLoginResponse(tokenData entity.SessionTokens) *ssov1.LoginResponse {
 	}
 }
 
-func fromRegisterUserRequest(req *ssov1.RegisterUserRequest) *entity.UserRequestData {
+func fromRegisterUserRequest(req *authv1.RegisterUserRequest) *entity.UserRequestData {
 	return &entity.UserRequestData{
 		Email:    req.GetEmail(),
 		Password: req.GetPassword(),
@@ -49,9 +50,9 @@ func fromRegisterUserRequest(req *ssov1.RegisterUserRequest) *entity.UserRequest
 	}
 }
 
-func toRegisterUserResponse(tokenData entity.SessionTokens) *ssov1.RegisterUserResponse {
-	return &ssov1.RegisterUserResponse{
-		TokenData: &ssov1.TokenData{
+func toRegisterUserResponse(tokenData entity.SessionTokens) *authv1.RegisterUserResponse {
+	return &authv1.RegisterUserResponse{
+		TokenData: &authv1.TokenData{
 			AccessToken:      tokenData.AccessToken,
 			RefreshToken:     tokenData.RefreshToken,
 			Domain:           tokenData.Domain,
@@ -63,27 +64,27 @@ func toRegisterUserResponse(tokenData entity.SessionTokens) *ssov1.RegisterUserR
 	}
 }
 
-func fromResetPasswordRequest(req *ssov1.ResetPasswordRequest) *entity.ResetPasswordRequestData {
+func fromResetPasswordRequest(req *authv1.ResetPasswordRequest) *entity.ResetPasswordRequestData {
 	return &entity.ResetPasswordRequestData{
 		Email: req.GetEmail(),
 	}
 }
 
-func fromChangePasswordRequest(req *ssov1.ChangePasswordRequest) *entity.ChangePasswordRequestData {
+func fromChangePasswordRequest(req *authv1.ChangePasswordRequest) *entity.ChangePasswordRequestData {
 	return &entity.ChangePasswordRequestData{
 		ResetPasswordToken: req.GetToken(),
 		UpdatedPassword:    req.GetUpdatedPassword(),
 	}
 }
 
-func fromLogoutRequest(req *ssov1.LogoutRequest) *entity.UserDeviceRequestData {
+func fromLogoutRequest(req *authv1.LogoutRequest) *entity.UserDeviceRequestData {
 	return &entity.UserDeviceRequestData{
 		UserAgent: req.UserDeviceData.GetUserAgent(),
 		IP:        req.UserDeviceData.GetIp(),
 	}
 }
 
-func fromRefreshRequest(req *ssov1.RefreshRequest) *entity.RefreshTokenRequestData {
+func fromRefreshRequest(req *authv1.RefreshTokensRequest) *entity.RefreshTokenRequestData {
 	return &entity.RefreshTokenRequestData{
 		RefreshToken: req.GetRefreshToken(),
 		UserDevice: entity.UserDeviceRequestData{
@@ -93,9 +94,9 @@ func fromRefreshRequest(req *ssov1.RefreshRequest) *entity.RefreshTokenRequestDa
 	}
 }
 
-func toRefreshResponse(tokenData entity.SessionTokens) *ssov1.RefreshResponse {
-	return &ssov1.RefreshResponse{
-		TokenData: &ssov1.TokenData{
+func toRefreshTokensResponse(tokenData entity.SessionTokens) *authv1.RefreshTokensResponse {
+	return &authv1.RefreshTokensResponse{
+		TokenData: &authv1.TokenData{
 			AccessToken:      tokenData.AccessToken,
 			RefreshToken:     tokenData.RefreshToken,
 			Domain:           tokenData.Domain,
@@ -107,11 +108,11 @@ func toRefreshResponse(tokenData entity.SessionTokens) *ssov1.RefreshResponse {
 	}
 }
 
-func toJWKSResponse(jwks entity.JWKS) *ssov1.GetJWKSResponse {
-	var jwksResponse []*ssov1.JWK
+func toJWKSResponse(jwks entity.JWKS) *authv1.GetJWKSResponse {
+	var jwksResponse []*authv1.JWK
 
 	for _, jwk := range jwks.Keys {
-		jwkResponse := &ssov1.JWK{
+		jwkResponse := &authv1.JWK{
 			Kty: jwk.Kty,
 			Kid: jwk.Kid,
 			Use: jwk.Use,
@@ -123,14 +124,14 @@ func toJWKSResponse(jwks entity.JWKS) *ssov1.GetJWKSResponse {
 		jwksResponse = append(jwksResponse, jwkResponse)
 	}
 
-	return &ssov1.GetJWKSResponse{
+	return &authv1.GetJWKSResponse{
 		Jwks: jwksResponse,
 	}
 }
 
-func toGetUserResponse(user entity.User) *ssov1.GetUserResponse {
-	return &ssov1.GetUserResponse{
-		User: &ssov1.User{
+func toGetUserResponse(user entity.User) *userv1.GetUserResponse {
+	return &userv1.GetUserResponse{
+		User: &userv1.User{
 			Id:        user.ID,
 			Email:     user.Email,
 			Verified:  user.Verified,
@@ -139,7 +140,7 @@ func toGetUserResponse(user entity.User) *ssov1.GetUserResponse {
 	}
 }
 
-func fromUpdateUserRequest(req *ssov1.UpdateUserRequest) entity.UserRequestData {
+func fromUpdateUserRequest(req *userv1.UpdateUserRequest) entity.UserRequestData {
 	return entity.UserRequestData{
 		Email:           req.GetEmail(),
 		Password:        req.GetCurrentPassword(),
@@ -147,16 +148,16 @@ func fromUpdateUserRequest(req *ssov1.UpdateUserRequest) entity.UserRequestData 
 	}
 }
 
-func toUpdateUserResponse(user entity.User) *ssov1.UpdateUserResponse {
-	return &ssov1.UpdateUserResponse{
+func toUpdateUserResponse(user entity.User) *userv1.UpdateUserResponse {
+	return &userv1.UpdateUserResponse{
 		Email:     user.Email,
 		UpdatedAt: timestamppb.New(user.UpdatedAt),
 	}
 }
 
-func toGetUserByIDResponse(user entity.User) *ssov1.GetUserByIDResponse {
-	return &ssov1.GetUserByIDResponse{
-		User: &ssov1.User{
+func toGetUserByIDResponse(user entity.User) *userv1.GetUserByIDResponse {
+	return &userv1.GetUserByIDResponse{
+		User: &userv1.User{
 			Id:        user.ID,
 			Email:     user.Email,
 			Verified:  user.Verified,

--- a/internal/controller/grpc/user.go
+++ b/internal/controller/grpc/user.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"log/slog"
 
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"github.com/rshelekhov/sso/internal/controller"
-
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
 	"github.com/rshelekhov/sso/internal/lib/e"
 )
 
-func (c *gRPCController) GetUser(ctx context.Context, req *ssov1.GetUserRequest) (*ssov1.GetUserResponse, error) {
+func (c *gRPCController) GetUser(ctx context.Context, req *userv1.GetUserRequest) (*userv1.GetUserResponse, error) {
 	const method = "controller.gRPC.GetUser"
 
 	log := c.log.With(slog.String("method", method))
@@ -39,7 +38,7 @@ func (c *gRPCController) GetUser(ctx context.Context, req *ssov1.GetUserRequest)
 	return toGetUserResponse(user), nil
 }
 
-func (c *gRPCController) GetUserByID(ctx context.Context, req *ssov1.GetUserByIDRequest) (*ssov1.GetUserByIDResponse, error) {
+func (c *gRPCController) GetUserByID(ctx context.Context, req *userv1.GetUserByIDRequest) (*userv1.GetUserByIDResponse, error) {
 	const method = "controller.gRPC.GetUserByID"
 
 	log := c.log.With(slog.String("method", method))
@@ -71,7 +70,7 @@ func (c *gRPCController) GetUserByID(ctx context.Context, req *ssov1.GetUserByID
 	return toGetUserByIDResponse(user), nil
 }
 
-func (c *gRPCController) UpdateUser(ctx context.Context, req *ssov1.UpdateUserRequest) (*ssov1.UpdateUserResponse, error) {
+func (c *gRPCController) UpdateUser(ctx context.Context, req *userv1.UpdateUserRequest) (*userv1.UpdateUserResponse, error) {
 	const method = "сontroller.gRPC.UpdateUser"
 
 	log := c.log.With(slog.String("method", method))
@@ -106,7 +105,7 @@ func (c *gRPCController) UpdateUser(ctx context.Context, req *ssov1.UpdateUserRe
 	return toUpdateUserResponse(updatedUser), nil
 }
 
-func (c *gRPCController) DeleteUser(ctx context.Context, req *ssov1.DeleteUserRequest) (*ssov1.DeleteUserResponse, error) {
+func (c *gRPCController) DeleteUser(ctx context.Context, req *userv1.DeleteUserRequest) (*userv1.DeleteUserResponse, error) {
 	const method = "сontroller.gRPC.DeleteUser"
 
 	log := c.log.With(slog.String("method", method))
@@ -131,10 +130,10 @@ func (c *gRPCController) DeleteUser(ctx context.Context, req *ssov1.DeleteUserRe
 		return nil, mapErrorToGRPCStatus(err)
 	}
 
-	return &ssov1.DeleteUserResponse{}, nil
+	return &userv1.DeleteUserResponse{}, nil
 }
 
-func (c *gRPCController) DeleteUserByID(ctx context.Context, req *ssov1.DeleteUserByIDRequest) (*ssov1.DeleteUserByIDResponse, error) {
+func (c *gRPCController) DeleteUserByID(ctx context.Context, req *userv1.DeleteUserByIDRequest) (*userv1.DeleteUserByIDResponse, error) {
 	const method = "controller.gRPC.DeleteUserByID"
 
 	log := c.log.With(slog.String("method", method))
@@ -163,5 +162,5 @@ func (c *gRPCController) DeleteUserByID(ctx context.Context, req *ssov1.DeleteUs
 		return nil, mapErrorToGRPCStatus(err)
 	}
 
-	return &ssov1.DeleteUserByIDResponse{}, nil
+	return &userv1.DeleteUserByIDResponse{}, nil
 }

--- a/internal/controller/grpc/validation.go
+++ b/internal/controller/grpc/validation.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
+	clientv1 "github.com/rshelekhov/sso-protos/gen/go/api/client/v1"
+	userv1 "github.com/rshelekhov/sso-protos/gen/go/api/user/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -64,8 +66,8 @@ func validateUserDeviceData(userAgent, ip string) error {
 	return nil
 }
 
-func validateRegisterAppRequest(req *ssov1.RegisterAppRequest) error {
-	appName := req.GetAppName()
+func validateRegisterClientRequest(req *clientv1.RegisterClientRequest) error {
+	appName := req.GetClientName()
 
 	if appName == emptyValue {
 		return status.Error(codes.InvalidArgument, ErrAppNameIsRequired.Error())
@@ -77,7 +79,7 @@ func validateRegisterAppRequest(req *ssov1.RegisterAppRequest) error {
 	return nil
 }
 
-func validateVerifyEmailRequest(req *ssov1.VerifyEmailRequest) error {
+func validateVerifyEmailRequest(req *authv1.VerifyEmailRequest) error {
 	if req.GetToken() == emptyValue {
 		return ErrVerificationTokenIsRequired
 	}
@@ -85,7 +87,7 @@ func validateVerifyEmailRequest(req *ssov1.VerifyEmailRequest) error {
 	return nil
 }
 
-func validateLoginRequest(req *ssov1.LoginRequest) error {
+func validateLoginRequest(req *authv1.LoginRequest) error {
 	var errMessages []string
 
 	if err := validateUserCredentials(req.GetEmail(), req.GetPassword()); err != nil {
@@ -102,7 +104,7 @@ func validateLoginRequest(req *ssov1.LoginRequest) error {
 	return nil
 }
 
-func validateRegisterUserRequest(req *ssov1.RegisterUserRequest) error {
+func validateRegisterUserRequest(req *authv1.RegisterUserRequest) error {
 	var errMessages []string
 
 	if err := validateUserCredentials(req.GetEmail(), req.GetPassword()); err != nil {
@@ -123,7 +125,7 @@ func validateRegisterUserRequest(req *ssov1.RegisterUserRequest) error {
 	return nil
 }
 
-func validateLogoutRequest(req *ssov1.LogoutRequest) error {
+func validateLogoutRequest(req *authv1.LogoutRequest) error {
 	if err := validateUserDeviceData(req.UserDeviceData.GetUserAgent(), req.UserDeviceData.GetIp()); err != nil {
 		return err
 	}
@@ -131,7 +133,7 @@ func validateLogoutRequest(req *ssov1.LogoutRequest) error {
 	return nil
 }
 
-func validateResetPasswordRequest(req *ssov1.ResetPasswordRequest) error {
+func validateResetPasswordRequest(req *authv1.ResetPasswordRequest) error {
 	var errMessages []string
 
 	if req.GetEmail() == emptyValue {
@@ -149,7 +151,7 @@ func validateResetPasswordRequest(req *ssov1.ResetPasswordRequest) error {
 	return nil
 }
 
-func validateChangePasswordRequest(req *ssov1.ChangePasswordRequest) error {
+func validateChangePasswordRequest(req *authv1.ChangePasswordRequest) error {
 	var errMessages []string
 
 	if req.GetToken() == emptyValue {
@@ -167,7 +169,7 @@ func validateChangePasswordRequest(req *ssov1.ChangePasswordRequest) error {
 	return nil
 }
 
-func validateRefreshRequest(req *ssov1.RefreshRequest) error {
+func validateRefreshRequest(req *authv1.RefreshTokensRequest) error {
 	var errMessages []string
 
 	if req.GetRefreshToken() == emptyValue {
@@ -185,14 +187,14 @@ func validateRefreshRequest(req *ssov1.RefreshRequest) error {
 	return nil
 }
 
-func validateGetUserByIDRequest(req *ssov1.GetUserByIDRequest) error {
+func validateGetUserByIDRequest(req *userv1.GetUserByIDRequest) error {
 	if req.GetUserId() == "" {
 		return status.Error(codes.InvalidArgument, ErrUserIDIsRequired.Error())
 	}
 	return nil
 }
 
-func validateUpdateUserRequest(req *ssov1.UpdateUserRequest) error {
+func validateUpdateUserRequest(req *userv1.UpdateUserRequest) error {
 	var errMessages []string
 
 	password := req.GetCurrentPassword()
@@ -210,7 +212,7 @@ func validateUpdateUserRequest(req *ssov1.UpdateUserRequest) error {
 	return nil
 }
 
-func validateDeleteUserByIDRequest(req *ssov1.DeleteUserByIDRequest) error {
+func validateDeleteUserByIDRequest(req *userv1.DeleteUserByIDRequest) error {
 	if req.GetUserId() == "" {
 		return status.Error(codes.InvalidArgument, ErrUserIDIsRequired.Error())
 	}

--- a/internal/lib/interceptor/clientid/clientid.go
+++ b/internal/lib/interceptor/clientid/clientid.go
@@ -20,12 +20,12 @@ func NewInterceptor(cfg *config.GRPCMethodsConfig) *Interceptor {
 }
 
 const (
-	Header = "X-App-ID"
-	CtxKey = "AppID"
+	Header = "X-Client-ID"
+	CtxKey = "ClientID"
 )
 
 func (i *Interceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		methodConfigs := i.cfg.GetMethodConfigs()
 		if methodConfig, exists := methodConfigs[info.FullMethod]; exists && methodConfig.RequireClientID {
 			clientID, err := extractFromGRPC(ctx)

--- a/pkg/jwtauth/README.md
+++ b/pkg/jwtauth/README.md
@@ -81,7 +81,7 @@ func main() {
     // Create JWT manager with remote provider and app ID
     jwtManager := jwtauth.NewManager(
         jwksProvider,
-        jwtauth.WithAppID("my-service"),
+        jwtauth.WithClientID("my-service"),
     )
 
     // Use in your gRPC server

--- a/pkg/jwtauth/errors.go
+++ b/pkg/jwtauth/errors.go
@@ -11,8 +11,8 @@ var (
 	ErrAuthorizationHeaderNotFoundInGRPCMetadata = errors.New("authorization header not found in gRPC metadata")
 	ErrAuthorizationHeaderNotFoundInHTTPRequest  = errors.New("authorization header not found in HTTP request")
 	ErrBearerTokenNotFound                       = errors.New("bearer token not found")
-	ErrAppIDHeaderNotFoundInGRPCMetadata         = errors.New("app ID header not found in gRPC metadata")
-	ErrAppIDHeaderNotFoundInHTTPRequest          = errors.New("app ID header not found in HTTP request")
+	ErrClientIDHeaderNotFoundInGRPCMetadata      = errors.New("client ID header not found in gRPC metadata")
+	ErrClientIDHeaderNotFoundInHTTPRequest       = errors.New("client ID header not found in HTTP request")
 
 	ErrKidNotFoundInTokenHeader = errors.New("kid not found in token header")
 	ErrKidIsNotAString          = errors.New("kid is not a string")

--- a/pkg/jwtauth/jwks_provider.go
+++ b/pkg/jwtauth/jwks_provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ssov1 "github.com/rshelekhov/sso-protos/gen/go/sso"
+	authv1 "github.com/rshelekhov/sso-protos/gen/go/api/auth/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -34,7 +34,7 @@ func (p *LocalJWKSProvider) GetJWKS(ctx context.Context, clientID string) ([]JWK
 }
 
 type RemoteJWKSProvider struct {
-	client ssov1.AuthClient
+	client authv1.AuthServiceClient
 	conn   *grpc.ClientConn
 }
 
@@ -48,7 +48,7 @@ func NewRemoteJWKSProvider(target string, opts ...grpc.DialOption) (*RemoteJWKSP
 		return nil, fmt.Errorf("failed to dial jwks service: %w", err)
 	}
 
-	client := ssov1.NewAuthClient(conn)
+	client := authv1.NewAuthServiceClient(conn)
 
 	return &RemoteJWKSProvider{
 		client: client,
@@ -57,7 +57,7 @@ func NewRemoteJWKSProvider(target string, opts ...grpc.DialOption) (*RemoteJWKSP
 }
 
 func (p *RemoteJWKSProvider) GetJWKS(ctx context.Context, clientID string) ([]JWK, error) {
-	resp, err := p.client.GetJWKS(ctx, &ssov1.GetJWKSRequest{})
+	resp, err := p.client.GetJWKS(ctx, &authv1.GetJWKSRequest{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get jwks: %w", err)
 	}

--- a/pkg/jwtauth/jwt_manager.go
+++ b/pkg/jwtauth/jwt_manager.go
@@ -46,7 +46,7 @@ func NewManager(jwksProvider JWKSProvider, opts ...Option) Manager {
 
 type Option func(m *manager)
 
-func WithAppID(clientID string) Option {
+func WithClientID(clientID string) Option {
 	return func(m *manager) {
 		m.clientID = clientID
 	}
@@ -54,7 +54,7 @@ func WithAppID(clientID string) Option {
 
 const (
 	AuthorizationHeader = "authorization"
-	AppIDHeader         = "X-App-ID"
+	ClientIDHeader      = "X-Client-ID"
 
 	AccessTokenKey  = "access_token"
 	RefreshTokenKey = "refresh_token"


### PR DESCRIPTION
## Key Changes

- **Renamed gRPC Client ID Interceptor**  
  Improved naming for better clarity and alignment with updated terminology.

- **Updated JWT Authentication Terminology**  
  Replaced all usage of `AppID` with `ClientID` in:
  - Error messages  
  - Method signatures  
  - `README.md`  
  This ensures consistency and reduces confusion in authentication-related logic.

- **Refactored gRPC API**  
  - Updated gRPC method paths to reflect the new service layout.
  - Refactored gRPC method implementations to use the latest `auth` and `client` proto definitions.

- **Updated Tests**  
  - Adjusted API test cases to use new `auth` and `user` proto schemas.
  - Ensured test coverage remains intact after proto structure changes.

- **Dependency Updates**  
  - Regenerated `go.mod` and `go.sum` to incorporate changes from updated protobuf and gRPC definitions.
