### PR TITLE
Remove ClientID from user/session/token domain and storage layers

### DIFF
--- a/internal/domain/entity/session.go
+++ b/internal/domain/entity/session.go
@@ -10,7 +10,6 @@ type (
 	Session struct {
 		ID            string
 		UserID        string
-		ClientID      string
 		DeviceID      string
 		RefreshToken  string
 		LastVisitedAt time.Time
@@ -19,9 +18,20 @@ type (
 
 	SessionRequestData struct {
 		UserID     string
-		ClientID   string
 		DeviceID   string
+		ClientID   string
 		UserDevice UserDeviceRequestData
+	}
+
+	// SessionTokens uses for creating user sessions
+	SessionTokens struct {
+		AccessToken      string
+		RefreshToken     string
+		Domain           string
+		Path             string
+		ExpiresAt        time.Time
+		HTTPOnly         bool
+		AdditionalFields map[string]string
 	}
 )
 
@@ -34,7 +44,6 @@ func NewSession(
 	return Session{
 		ID:            ksuid.New().String(),
 		UserID:        reqData.UserID,
-		ClientID:      reqData.ClientID,
 		DeviceID:      reqData.DeviceID,
 		RefreshToken:  refreshToken,
 		LastVisitedAt: currentTime,

--- a/internal/domain/entity/token.go
+++ b/internal/domain/entity/token.go
@@ -8,23 +8,10 @@ const (
 	IssuerKey = "issuer"
 )
 
-type (
-	// SessionTokens uses for creating user sessions
-	SessionTokens struct {
-		AccessToken      string
-		RefreshToken     string
-		Domain           string
-		Path             string
-		ExpiresAt        time.Time
-		HTTPOnly         bool
-		AdditionalFields map[string]string
-	}
-
-	RefreshTokenRequestData struct {
-		RefreshToken string
-		UserDevice   UserDeviceRequestData
-	}
-)
+type RefreshTokenRequestData struct {
+	RefreshToken string
+	UserDevice   UserDeviceRequestData
+}
 
 type VerificationTokenType int
 
@@ -37,7 +24,6 @@ const (
 type VerificationToken struct {
 	Token     string
 	UserID    string
-	ClientID  string
 	Endpoint  string
 	Email     string
 	Type      VerificationTokenType
@@ -56,7 +42,6 @@ func NewVerificationToken(
 	return VerificationToken{
 		Token:     token,
 		UserID:    user.ID,
-		ClientID:  user.ClientID,
 		Endpoint:  endpoint,
 		Email:     user.Email,
 		Type:      tokenType,

--- a/internal/domain/entity/user.go
+++ b/internal/domain/entity/user.go
@@ -23,7 +23,6 @@ type (
 		ID           string
 		Email        string
 		PasswordHash string
-		ClientID     string
 		Verified     bool
 		Status       userStatusType
 		CreatedAt    time.Time
@@ -39,12 +38,11 @@ type (
 	}
 )
 
-func NewUser(clientID, email, hash string) User {
+func NewUser(email, hash string) User {
 	return User{
 		ID:           ksuid.New().String(),
 		Email:        email,
 		PasswordHash: hash,
-		ClientID:     clientID,
 		Verified:     false,
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),

--- a/internal/domain/entity/user_device.go
+++ b/internal/domain/entity/user_device.go
@@ -10,7 +10,6 @@ type (
 	UserDevice struct {
 		ID            string
 		UserID        string
-		ClientID      string
 		UserAgent     string
 		IP            string
 		Detached      bool
@@ -28,7 +27,6 @@ func NewUserDevice(session SessionRequestData) UserDevice {
 	return UserDevice{
 		ID:            ksuid.New().String(),
 		UserID:        session.UserID,
-		ClientID:      session.ClientID,
 		UserAgent:     session.UserDevice.UserAgent,
 		IP:            session.UserDevice.IP,
 		Detached:      false,

--- a/internal/domain/service/session/mocks/mock_DeviceStorage.go
+++ b/internal/domain/service/session/mocks/mock_DeviceStorage.go
@@ -22,17 +22,17 @@ func (_m *DeviceStorage) EXPECT() *DeviceStorage_Expecter {
 	return &DeviceStorage_Expecter{mock: &_m.Mock}
 }
 
-// DeleteAllUserDevices provides a mock function with given fields: ctx, userID, clientID
-func (_m *DeviceStorage) DeleteAllUserDevices(ctx context.Context, userID string, clientID string) error {
-	ret := _m.Called(ctx, userID, clientID)
+// DeleteAllUserDevices provides a mock function with given fields: ctx, userID
+func (_m *DeviceStorage) DeleteAllUserDevices(ctx context.Context, userID string) error {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAllUserDevices")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, userID, clientID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -48,14 +48,13 @@ type DeviceStorage_DeleteAllUserDevices_Call struct {
 // DeleteAllUserDevices is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userID string
-//   - clientID string
-func (_e *DeviceStorage_Expecter) DeleteAllUserDevices(ctx interface{}, userID interface{}, clientID interface{}) *DeviceStorage_DeleteAllUserDevices_Call {
-	return &DeviceStorage_DeleteAllUserDevices_Call{Call: _e.mock.On("DeleteAllUserDevices", ctx, userID, clientID)}
+func (_e *DeviceStorage_Expecter) DeleteAllUserDevices(ctx interface{}, userID interface{}) *DeviceStorage_DeleteAllUserDevices_Call {
+	return &DeviceStorage_DeleteAllUserDevices_Call{Call: _e.mock.On("DeleteAllUserDevices", ctx, userID)}
 }
 
-func (_c *DeviceStorage_DeleteAllUserDevices_Call) Run(run func(ctx context.Context, userID string, clientID string)) *DeviceStorage_DeleteAllUserDevices_Call {
+func (_c *DeviceStorage_DeleteAllUserDevices_Call) Run(run func(ctx context.Context, userID string)) *DeviceStorage_DeleteAllUserDevices_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -65,14 +64,14 @@ func (_c *DeviceStorage_DeleteAllUserDevices_Call) Return(_a0 error) *DeviceStor
 	return _c
 }
 
-func (_c *DeviceStorage_DeleteAllUserDevices_Call) RunAndReturn(run func(context.Context, string, string) error) *DeviceStorage_DeleteAllUserDevices_Call {
+func (_c *DeviceStorage_DeleteAllUserDevices_Call) RunAndReturn(run func(context.Context, string) error) *DeviceStorage_DeleteAllUserDevices_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserDeviceID provides a mock function with given fields: ctx, userID, clientID, userAgent
-func (_m *DeviceStorage) GetUserDeviceID(ctx context.Context, userID string, clientID string, userAgent string) (string, error) {
-	ret := _m.Called(ctx, userID, clientID, userAgent)
+// GetUserDeviceID provides a mock function with given fields: ctx, userID, userAgent
+func (_m *DeviceStorage) GetUserDeviceID(ctx context.Context, userID string, userAgent string) (string, error) {
+	ret := _m.Called(ctx, userID, userAgent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserDeviceID")
@@ -80,17 +79,17 @@ func (_m *DeviceStorage) GetUserDeviceID(ctx context.Context, userID string, cli
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (string, error)); ok {
-		return rf(ctx, userID, clientID, userAgent)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
+		return rf(ctx, userID, userAgent)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) string); ok {
-		r0 = rf(ctx, userID, clientID, userAgent)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
+		r0 = rf(ctx, userID, userAgent)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, userID, clientID, userAgent)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, userID, userAgent)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -106,15 +105,14 @@ type DeviceStorage_GetUserDeviceID_Call struct {
 // GetUserDeviceID is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userID string
-//   - clientID string
 //   - userAgent string
-func (_e *DeviceStorage_Expecter) GetUserDeviceID(ctx interface{}, userID interface{}, clientID interface{}, userAgent interface{}) *DeviceStorage_GetUserDeviceID_Call {
-	return &DeviceStorage_GetUserDeviceID_Call{Call: _e.mock.On("GetUserDeviceID", ctx, userID, clientID, userAgent)}
+func (_e *DeviceStorage_Expecter) GetUserDeviceID(ctx interface{}, userID interface{}, userAgent interface{}) *DeviceStorage_GetUserDeviceID_Call {
+	return &DeviceStorage_GetUserDeviceID_Call{Call: _e.mock.On("GetUserDeviceID", ctx, userID, userAgent)}
 }
 
-func (_c *DeviceStorage_GetUserDeviceID_Call) Run(run func(ctx context.Context, userID string, clientID string, userAgent string)) *DeviceStorage_GetUserDeviceID_Call {
+func (_c *DeviceStorage_GetUserDeviceID_Call) Run(run func(ctx context.Context, userID string, userAgent string)) *DeviceStorage_GetUserDeviceID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -124,7 +122,7 @@ func (_c *DeviceStorage_GetUserDeviceID_Call) Return(_a0 string, _a1 error) *Dev
 	return _c
 }
 
-func (_c *DeviceStorage_GetUserDeviceID_Call) RunAndReturn(run func(context.Context, string, string, string) (string, error)) *DeviceStorage_GetUserDeviceID_Call {
+func (_c *DeviceStorage_GetUserDeviceID_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *DeviceStorage_GetUserDeviceID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/service/session/mocks/mock_SessionStorage.go
+++ b/internal/domain/service/session/mocks/mock_SessionStorage.go
@@ -69,17 +69,17 @@ func (_c *SessionStorage_CreateSession_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
-// DeleteAllSessions provides a mock function with given fields: ctx, userID, clientID
-func (_m *SessionStorage) DeleteAllSessions(ctx context.Context, userID string, clientID string) error {
-	ret := _m.Called(ctx, userID, clientID)
+// DeleteAllSessions provides a mock function with given fields: ctx, userID
+func (_m *SessionStorage) DeleteAllSessions(ctx context.Context, userID string) error {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAllSessions")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, userID, clientID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -95,14 +95,13 @@ type SessionStorage_DeleteAllSessions_Call struct {
 // DeleteAllSessions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userID string
-//   - clientID string
-func (_e *SessionStorage_Expecter) DeleteAllSessions(ctx interface{}, userID interface{}, clientID interface{}) *SessionStorage_DeleteAllSessions_Call {
-	return &SessionStorage_DeleteAllSessions_Call{Call: _e.mock.On("DeleteAllSessions", ctx, userID, clientID)}
+func (_e *SessionStorage_Expecter) DeleteAllSessions(ctx interface{}, userID interface{}) *SessionStorage_DeleteAllSessions_Call {
+	return &SessionStorage_DeleteAllSessions_Call{Call: _e.mock.On("DeleteAllSessions", ctx, userID)}
 }
 
-func (_c *SessionStorage_DeleteAllSessions_Call) Run(run func(ctx context.Context, userID string, clientID string)) *SessionStorage_DeleteAllSessions_Call {
+func (_c *SessionStorage_DeleteAllSessions_Call) Run(run func(ctx context.Context, userID string)) *SessionStorage_DeleteAllSessions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -112,7 +111,7 @@ func (_c *SessionStorage_DeleteAllSessions_Call) Return(_a0 error) *SessionStora
 	return _c
 }
 
-func (_c *SessionStorage_DeleteAllSessions_Call) RunAndReturn(run func(context.Context, string, string) error) *SessionStorage_DeleteAllSessions_Call {
+func (_c *SessionStorage_DeleteAllSessions_Call) RunAndReturn(run func(context.Context, string) error) *SessionStorage_DeleteAllSessions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/service/session/session_service.go
+++ b/internal/domain/service/session/session_service.go
@@ -13,7 +13,7 @@ import (
 
 type (
 	JWTManager interface {
-		NewAccessToken(clientID, kid string, additionalClaims map[string]interface{}) (string, error)
+		NewAccessToken(clientID, kid string, additionalClaims map[string]any) (string, error)
 		NewRefreshToken() string
 		Issuer() string
 		AccessTokenTTL() time.Duration
@@ -28,14 +28,14 @@ type (
 		GetSessionByRefreshToken(ctx context.Context, refreshToken string) (entity.Session, error)
 		DeleteRefreshToken(ctx context.Context, refreshToken string) error
 		DeleteSession(ctx context.Context, session entity.Session) error
-		DeleteAllSessions(ctx context.Context, userID, clientID string) error
+		DeleteAllSessions(ctx context.Context, userID string) error
 	}
 
 	DeviceStorage interface {
 		RegisterDevice(ctx context.Context, device entity.UserDevice) error
-		GetUserDeviceID(ctx context.Context, userID, clientID, userAgent string) (string, error)
+		GetUserDeviceID(ctx context.Context, userID, userAgent string) (string, error)
 		UpdateLastVisitedAt(ctx context.Context, session entity.Session) error
-		DeleteAllUserDevices(ctx context.Context, userID, clientID string) error
+		DeleteAllUserDevices(ctx context.Context, userID string) error
 	}
 )
 
@@ -100,10 +100,10 @@ func (s *Session) GetSessionByRefreshToken(ctx context.Context, refreshToken str
 	return session, nil
 }
 
-func (s *Session) GetUserDeviceID(ctx context.Context, userID, clientID, userAgent string) (string, error) {
+func (s *Session) GetUserDeviceID(ctx context.Context, userID, userAgent string) (string, error) {
 	const method = "service.session.GetUserDeviceID"
 
-	deviceID, err := s.deviceStorage.GetUserDeviceID(ctx, userID, clientID, userAgent)
+	deviceID, err := s.deviceStorage.GetUserDeviceID(ctx, userID, userAgent)
 	if err != nil {
 		if errors.Is(err, storage.ErrUserDeviceNotFound) {
 			return "", domain.ErrUserDeviceNotFound
@@ -130,7 +130,6 @@ func (s *Session) DeleteSession(ctx context.Context, sessionReqData entity.Sessi
 	if err := s.sessionStorage.DeleteSession(ctx, entity.Session{
 		UserID:   sessionReqData.UserID,
 		DeviceID: sessionReqData.DeviceID,
-		ClientID: sessionReqData.ClientID,
 	}); err != nil {
 		return fmt.Errorf("%s: %w", method, err)
 	}
@@ -141,7 +140,7 @@ func (s *Session) DeleteSession(ctx context.Context, sessionReqData entity.Sessi
 func (s *Session) DeleteUserSessions(ctx context.Context, user entity.User) error {
 	const method = "service.session.DeleteAllUserSessions"
 
-	if err := s.sessionStorage.DeleteAllSessions(ctx, user.ID, user.ClientID); err != nil {
+	if err := s.sessionStorage.DeleteAllSessions(ctx, user.ID); err != nil {
 		return fmt.Errorf("%s: %w", method, err)
 	}
 
@@ -151,7 +150,7 @@ func (s *Session) DeleteUserSessions(ctx context.Context, user entity.User) erro
 func (s *Session) DeleteUserDevices(ctx context.Context, user entity.User) error {
 	const method = "service.session.DeleteUserDevices"
 
-	if err := s.deviceStorage.DeleteAllUserDevices(ctx, user.ID, user.ClientID); err != nil {
+	if err := s.deviceStorage.DeleteAllUserDevices(ctx, user.ID); err != nil {
 		return fmt.Errorf("%s: %w", method, err)
 	}
 
@@ -167,7 +166,7 @@ func (s *Session) prepareTokenConfig() (issuer string, accessTokenTTL, refreshTo
 }
 
 func (s *Session) getOrRegisterDeviceID(ctx context.Context, session entity.SessionRequestData) (string, error) {
-	deviceID, err := s.deviceStorage.GetUserDeviceID(ctx, session.UserID, session.ClientID, session.UserDevice.UserAgent)
+	deviceID, err := s.deviceStorage.GetUserDeviceID(ctx, session.UserID, session.UserDevice.UserAgent)
 	if err != nil {
 		if errors.Is(err, storage.ErrUserDeviceNotFound) {
 			return s.registerDevice(ctx, session)
@@ -203,7 +202,7 @@ func (s *Session) createTokens(
 		return "", "", fmt.Errorf("%w: %w", domain.ErrFailedToGetKeyID, err)
 	}
 
-	additionalClaims := map[string]interface{}{
+	additionalClaims := map[string]any{
 		domain.IssuerKey:       issuer,
 		domain.UserIDKey:       session.UserID,
 		domain.ClientIDKey:     session.ClientID,

--- a/internal/domain/service/session/session_service_test.go
+++ b/internal/domain/service/session/session_service_test.go
@@ -102,7 +102,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 					Once().
 					Return(cookiePath)
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return(deviceID, nil)
 
@@ -157,7 +157,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 					Once().
 					Return(cookiePath)
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return("", storage.ErrUserDeviceNotFound)
 
@@ -196,7 +196,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 					Once().
 					Return(refreshTokenTTL)
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return("", errors.New("failed to get device ID"))
 			},
@@ -227,7 +227,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 					Once().
 					Return("", domain.ErrFailedToGetKeyID)
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return(deviceID, nil)
 			},
@@ -261,7 +261,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 				jwtManager.EXPECT().NewAccessToken(sessionReqData.ClientID, kid, mock.Anything).
 					Once().Return("", errors.New("jwt manager error"))
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return(deviceID, nil)
 			},
@@ -300,7 +300,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 					Once().
 					Return(refreshTokenStr)
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return(deviceID, nil)
 
@@ -342,7 +342,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 					Once().
 					Return(refreshTokenStr)
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return(deviceID, nil)
 
@@ -376,7 +376,7 @@ func TestSessionService_CreateSession(t *testing.T) {
 					Once().
 					Return(refreshTokenTTL)
 
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return("", storage.ErrUserDeviceNotFound)
 
@@ -436,7 +436,6 @@ func TestSessionService_GetSessionByRefreshToken(t *testing.T) {
 					Once().
 					Return(entity.Session{
 						UserID:        "test-user-id",
-						ClientID:      "test-client-id",
 						DeviceID:      "test-device-id",
 						RefreshToken:  refreshToken,
 						LastVisitedAt: time.Now(),
@@ -465,7 +464,6 @@ func TestSessionService_GetSessionByRefreshToken(t *testing.T) {
 					Once().
 					Return(entity.Session{
 						UserID:        "test-user-id",
-						ClientID:      "test-client-id",
 						DeviceID:      "test-device-id",
 						RefreshToken:  refreshToken,
 						LastVisitedAt: time.Now(),
@@ -533,7 +531,7 @@ func TestSessionService_GetUserDeviceID(t *testing.T) {
 			name:    "Success",
 			reqData: sessionReqData,
 			mockBehavior: func(deviceStorage *mocks.DeviceStorage) {
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return("test-device-id", nil)
 			},
@@ -544,7 +542,7 @@ func TestSessionService_GetUserDeviceID(t *testing.T) {
 			name:    "Device not found",
 			reqData: sessionReqData,
 			mockBehavior: func(deviceStorage *mocks.DeviceStorage) {
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return("", storage.ErrUserDeviceNotFound)
 			},
@@ -555,7 +553,7 @@ func TestSessionService_GetUserDeviceID(t *testing.T) {
 			name:    "Failed to get device ID",
 			reqData: sessionReqData,
 			mockBehavior: func(deviceStorage *mocks.DeviceStorage) {
-				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.ClientID, sessionReqData.UserDevice.UserAgent).
+				deviceStorage.EXPECT().GetUserDeviceID(ctx, sessionReqData.UserID, sessionReqData.UserDevice.UserAgent).
 					Once().
 					Return("", errors.New("failed to get device id"))
 			},
@@ -571,7 +569,7 @@ func TestSessionService_GetUserDeviceID(t *testing.T) {
 
 			service := NewService(nil, nil, deviceStorage)
 
-			deviceID, err := service.GetUserDeviceID(ctx, tt.reqData.UserID, tt.reqData.ClientID, tt.reqData.UserDevice.UserAgent)
+			deviceID, err := service.GetUserDeviceID(ctx, tt.reqData.UserID, tt.reqData.UserDevice.UserAgent)
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
@@ -645,7 +643,6 @@ func TestSessionService_DeleteSession(t *testing.T) {
 	sessionReqData := entity.SessionRequestData{
 		UserID:   "test-user-id",
 		DeviceID: "test-device-id",
-		ClientID: "test-client-id",
 	}
 
 	tests := []struct {
@@ -661,7 +658,6 @@ func TestSessionService_DeleteSession(t *testing.T) {
 				sessionStorage.EXPECT().DeleteSession(ctx, entity.Session{
 					UserID:   sessionReqData.UserID,
 					DeviceID: sessionReqData.DeviceID,
-					ClientID: sessionReqData.ClientID,
 				}).
 					Once().
 					Return(nil)
@@ -675,7 +671,6 @@ func TestSessionService_DeleteSession(t *testing.T) {
 				sessionStorage.EXPECT().DeleteSession(ctx, entity.Session{
 					UserID:   sessionReqData.UserID,
 					DeviceID: sessionReqData.DeviceID,
-					ClientID: sessionReqData.ClientID,
 				}).
 					Once().
 					Return(errors.New("failed to delete session"))
@@ -719,7 +714,7 @@ func TestSessionService_DeleteUserSessions(t *testing.T) {
 			name: "Success",
 			user: user,
 			mockBehavior: func(sessionStorage *mocks.SessionStorage) {
-				sessionStorage.EXPECT().DeleteAllSessions(ctx, user.ID, "").
+				sessionStorage.EXPECT().DeleteAllSessions(ctx, user.ID).
 					Once().
 					Return(nil)
 			},
@@ -729,7 +724,7 @@ func TestSessionService_DeleteUserSessions(t *testing.T) {
 			name: "Failed to delete user sessions",
 			user: user,
 			mockBehavior: func(sessionStorage *mocks.SessionStorage) {
-				sessionStorage.EXPECT().DeleteAllSessions(ctx, user.ID, "").
+				sessionStorage.EXPECT().DeleteAllSessions(ctx, user.ID).
 					Once().
 					Return(errors.New("failed to delete user sessions"))
 			},
@@ -759,8 +754,7 @@ func TestSessionService_DeleteUserSessions(t *testing.T) {
 func TestSessionService_DeleteUserDevices(t *testing.T) {
 	ctx := context.Background()
 	user := entity.User{
-		ID:       "test-user-id",
-		ClientID: "test-client-id",
+		ID: "test-user-id",
 	}
 
 	tests := []struct {
@@ -773,7 +767,7 @@ func TestSessionService_DeleteUserDevices(t *testing.T) {
 			name: "Success",
 			user: user,
 			mockBehavior: func(deviceStorage *mocks.DeviceStorage) {
-				deviceStorage.EXPECT().DeleteAllUserDevices(ctx, user.ID, user.ClientID).
+				deviceStorage.EXPECT().DeleteAllUserDevices(ctx, user.ID).
 					Once().
 					Return(nil)
 			},
@@ -783,7 +777,7 @@ func TestSessionService_DeleteUserDevices(t *testing.T) {
 			name: "Failed to delete user devices",
 			user: user,
 			mockBehavior: func(deviceStorage *mocks.DeviceStorage) {
-				deviceStorage.EXPECT().DeleteAllUserDevices(ctx, user.ID, user.ClientID).
+				deviceStorage.EXPECT().DeleteAllUserDevices(ctx, user.ID).
 					Once().
 					Return(errors.New("failed to delete user devices"))
 			},

--- a/internal/domain/service/userdata/mocks/mock_Storage.go
+++ b/internal/domain/service/userdata/mocks/mock_Storage.go
@@ -69,9 +69,9 @@ func (_c *Storage_DeleteUser_Call) RunAndReturn(run func(context.Context, entity
 	return _c
 }
 
-// GetUserByEmail provides a mock function with given fields: ctx, clientID, email
-func (_m *Storage) GetUserByEmail(ctx context.Context, clientID string, email string) (entity.User, error) {
-	ret := _m.Called(ctx, clientID, email)
+// GetUserByEmail provides a mock function with given fields: ctx, email
+func (_m *Storage) GetUserByEmail(ctx context.Context, email string) (entity.User, error) {
+	ret := _m.Called(ctx, email)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserByEmail")
@@ -79,17 +79,17 @@ func (_m *Storage) GetUserByEmail(ctx context.Context, clientID string, email st
 
 	var r0 entity.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (entity.User, error)); ok {
-		return rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (entity.User, error)); ok {
+		return rf(ctx, email)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) entity.User); ok {
-		r0 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) entity.User); ok {
+		r0 = rf(ctx, email)
 	} else {
 		r0 = ret.Get(0).(entity.User)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, email)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -104,15 +104,14 @@ type Storage_GetUserByEmail_Call struct {
 
 // GetUserByEmail is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - email string
-func (_e *Storage_Expecter) GetUserByEmail(ctx interface{}, clientID interface{}, email interface{}) *Storage_GetUserByEmail_Call {
-	return &Storage_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", ctx, clientID, email)}
+func (_e *Storage_Expecter) GetUserByEmail(ctx interface{}, email interface{}) *Storage_GetUserByEmail_Call {
+	return &Storage_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", ctx, email)}
 }
 
-func (_c *Storage_GetUserByEmail_Call) Run(run func(ctx context.Context, clientID string, email string)) *Storage_GetUserByEmail_Call {
+func (_c *Storage_GetUserByEmail_Call) Run(run func(ctx context.Context, email string)) *Storage_GetUserByEmail_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -122,14 +121,14 @@ func (_c *Storage_GetUserByEmail_Call) Return(_a0 entity.User, _a1 error) *Stora
 	return _c
 }
 
-func (_c *Storage_GetUserByEmail_Call) RunAndReturn(run func(context.Context, string, string) (entity.User, error)) *Storage_GetUserByEmail_Call {
+func (_c *Storage_GetUserByEmail_Call) RunAndReturn(run func(context.Context, string) (entity.User, error)) *Storage_GetUserByEmail_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserByID provides a mock function with given fields: ctx, clientID, userID
-func (_m *Storage) GetUserByID(ctx context.Context, clientID string, userID string) (entity.User, error) {
-	ret := _m.Called(ctx, clientID, userID)
+// GetUserByID provides a mock function with given fields: ctx, userID
+func (_m *Storage) GetUserByID(ctx context.Context, userID string) (entity.User, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserByID")
@@ -137,17 +136,17 @@ func (_m *Storage) GetUserByID(ctx context.Context, clientID string, userID stri
 
 	var r0 entity.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (entity.User, error)); ok {
-		return rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (entity.User, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) entity.User); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) entity.User); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Get(0).(entity.User)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -162,15 +161,14 @@ type Storage_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *Storage_Expecter) GetUserByID(ctx interface{}, clientID interface{}, userID interface{}) *Storage_GetUserByID_Call {
-	return &Storage_GetUserByID_Call{Call: _e.mock.On("GetUserByID", ctx, clientID, userID)}
+func (_e *Storage_Expecter) GetUserByID(ctx interface{}, userID interface{}) *Storage_GetUserByID_Call {
+	return &Storage_GetUserByID_Call{Call: _e.mock.On("GetUserByID", ctx, userID)}
 }
 
-func (_c *Storage_GetUserByID_Call) Run(run func(ctx context.Context, clientID string, userID string)) *Storage_GetUserByID_Call {
+func (_c *Storage_GetUserByID_Call) Run(run func(ctx context.Context, userID string)) *Storage_GetUserByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -180,14 +178,14 @@ func (_c *Storage_GetUserByID_Call) Return(_a0 entity.User, _a1 error) *Storage_
 	return _c
 }
 
-func (_c *Storage_GetUserByID_Call) RunAndReturn(run func(context.Context, string, string) (entity.User, error)) *Storage_GetUserByID_Call {
+func (_c *Storage_GetUserByID_Call) RunAndReturn(run func(context.Context, string) (entity.User, error)) *Storage_GetUserByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserData provides a mock function with given fields: ctx, clientID, userID
-func (_m *Storage) GetUserData(ctx context.Context, clientID string, userID string) (entity.User, error) {
-	ret := _m.Called(ctx, clientID, userID)
+// GetUserData provides a mock function with given fields: ctx, userID
+func (_m *Storage) GetUserData(ctx context.Context, userID string) (entity.User, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserData")
@@ -195,17 +193,17 @@ func (_m *Storage) GetUserData(ctx context.Context, clientID string, userID stri
 
 	var r0 entity.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (entity.User, error)); ok {
-		return rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (entity.User, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) entity.User); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) entity.User); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Get(0).(entity.User)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -220,15 +218,14 @@ type Storage_GetUserData_Call struct {
 
 // GetUserData is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *Storage_Expecter) GetUserData(ctx interface{}, clientID interface{}, userID interface{}) *Storage_GetUserData_Call {
-	return &Storage_GetUserData_Call{Call: _e.mock.On("GetUserData", ctx, clientID, userID)}
+func (_e *Storage_Expecter) GetUserData(ctx interface{}, userID interface{}) *Storage_GetUserData_Call {
+	return &Storage_GetUserData_Call{Call: _e.mock.On("GetUserData", ctx, userID)}
 }
 
-func (_c *Storage_GetUserData_Call) Run(run func(ctx context.Context, clientID string, userID string)) *Storage_GetUserData_Call {
+func (_c *Storage_GetUserData_Call) Run(run func(ctx context.Context, userID string)) *Storage_GetUserData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -238,14 +235,14 @@ func (_c *Storage_GetUserData_Call) Return(_a0 entity.User, _a1 error) *Storage_
 	return _c
 }
 
-func (_c *Storage_GetUserData_Call) RunAndReturn(run func(context.Context, string, string) (entity.User, error)) *Storage_GetUserData_Call {
+func (_c *Storage_GetUserData_Call) RunAndReturn(run func(context.Context, string) (entity.User, error)) *Storage_GetUserData_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserStatusByEmail provides a mock function with given fields: ctx, clientID, email
-func (_m *Storage) GetUserStatusByEmail(ctx context.Context, clientID string, email string) (string, error) {
-	ret := _m.Called(ctx, clientID, email)
+// GetUserStatusByEmail provides a mock function with given fields: ctx, email
+func (_m *Storage) GetUserStatusByEmail(ctx context.Context, email string) (string, error) {
+	ret := _m.Called(ctx, email)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserStatusByEmail")
@@ -253,17 +250,17 @@ func (_m *Storage) GetUserStatusByEmail(ctx context.Context, clientID string, em
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
-		return rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, email)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, email)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, email)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -278,15 +275,14 @@ type Storage_GetUserStatusByEmail_Call struct {
 
 // GetUserStatusByEmail is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - email string
-func (_e *Storage_Expecter) GetUserStatusByEmail(ctx interface{}, clientID interface{}, email interface{}) *Storage_GetUserStatusByEmail_Call {
-	return &Storage_GetUserStatusByEmail_Call{Call: _e.mock.On("GetUserStatusByEmail", ctx, clientID, email)}
+func (_e *Storage_Expecter) GetUserStatusByEmail(ctx interface{}, email interface{}) *Storage_GetUserStatusByEmail_Call {
+	return &Storage_GetUserStatusByEmail_Call{Call: _e.mock.On("GetUserStatusByEmail", ctx, email)}
 }
 
-func (_c *Storage_GetUserStatusByEmail_Call) Run(run func(ctx context.Context, clientID string, email string)) *Storage_GetUserStatusByEmail_Call {
+func (_c *Storage_GetUserStatusByEmail_Call) Run(run func(ctx context.Context, email string)) *Storage_GetUserStatusByEmail_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -296,14 +292,14 @@ func (_c *Storage_GetUserStatusByEmail_Call) Return(_a0 string, _a1 error) *Stor
 	return _c
 }
 
-func (_c *Storage_GetUserStatusByEmail_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *Storage_GetUserStatusByEmail_Call {
+func (_c *Storage_GetUserStatusByEmail_Call) RunAndReturn(run func(context.Context, string) (string, error)) *Storage_GetUserStatusByEmail_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserStatusByID provides a mock function with given fields: ctx, clientID, userID
-func (_m *Storage) GetUserStatusByID(ctx context.Context, clientID string, userID string) (string, error) {
-	ret := _m.Called(ctx, clientID, userID)
+// GetUserStatusByID provides a mock function with given fields: ctx, userID
+func (_m *Storage) GetUserStatusByID(ctx context.Context, userID string) (string, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserStatusByID")
@@ -311,17 +307,17 @@ func (_m *Storage) GetUserStatusByID(ctx context.Context, clientID string, userI
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
-		return rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -336,15 +332,14 @@ type Storage_GetUserStatusByID_Call struct {
 
 // GetUserStatusByID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *Storage_Expecter) GetUserStatusByID(ctx interface{}, clientID interface{}, userID interface{}) *Storage_GetUserStatusByID_Call {
-	return &Storage_GetUserStatusByID_Call{Call: _e.mock.On("GetUserStatusByID", ctx, clientID, userID)}
+func (_e *Storage_Expecter) GetUserStatusByID(ctx interface{}, userID interface{}) *Storage_GetUserStatusByID_Call {
+	return &Storage_GetUserStatusByID_Call{Call: _e.mock.On("GetUserStatusByID", ctx, userID)}
 }
 
-func (_c *Storage_GetUserStatusByID_Call) Run(run func(ctx context.Context, clientID string, userID string)) *Storage_GetUserStatusByID_Call {
+func (_c *Storage_GetUserStatusByID_Call) Run(run func(ctx context.Context, userID string)) *Storage_GetUserStatusByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -354,7 +349,7 @@ func (_c *Storage_GetUserStatusByID_Call) Return(_a0 string, _a1 error) *Storage
 	return _c
 }
 
-func (_c *Storage_GetUserStatusByID_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *Storage_GetUserStatusByID_Call {
+func (_c *Storage_GetUserStatusByID_Call) RunAndReturn(run func(context.Context, string) (string, error)) *Storage_GetUserStatusByID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/service/userdata/userdata_service.go
+++ b/internal/domain/service/userdata/userdata_service.go
@@ -15,12 +15,12 @@ type UserData struct {
 }
 
 type Storage interface {
-	GetUserByID(ctx context.Context, clientID, userID string) (entity.User, error)
-	GetUserByEmail(ctx context.Context, clientID, email string) (entity.User, error)
-	GetUserData(ctx context.Context, clientID, userID string) (entity.User, error)
+	GetUserByID(ctx context.Context, userID string) (entity.User, error)
+	GetUserByEmail(ctx context.Context, email string) (entity.User, error)
+	GetUserData(ctx context.Context, userID string) (entity.User, error)
 	UpdateUser(ctx context.Context, user entity.User) error
-	GetUserStatusByEmail(ctx context.Context, clientID, email string) (string, error)
-	GetUserStatusByID(ctx context.Context, clientID, userID string) (string, error)
+	GetUserStatusByEmail(ctx context.Context, email string) (string, error)
+	GetUserStatusByID(ctx context.Context, userID string) (string, error)
 	DeleteUser(ctx context.Context, user entity.User) error
 }
 
@@ -30,10 +30,10 @@ func NewService(storage Storage) *UserData {
 	}
 }
 
-func (d *UserData) GetUserByID(ctx context.Context, clientID, userID string) (entity.User, error) {
+func (d *UserData) GetUserByID(ctx context.Context, userID string) (entity.User, error) {
 	const method = "service.user.GetUserByID"
 
-	user, err := d.storage.GetUserByID(ctx, clientID, userID)
+	user, err := d.storage.GetUserByID(ctx, userID)
 	if err != nil {
 		if errors.Is(err, storage.ErrUserNotFound) {
 			return entity.User{}, domain.ErrUserNotFound
@@ -44,10 +44,10 @@ func (d *UserData) GetUserByID(ctx context.Context, clientID, userID string) (en
 	return user, nil
 }
 
-func (d *UserData) GetUserByEmail(ctx context.Context, clientID, email string) (entity.User, error) {
+func (d *UserData) GetUserByEmail(ctx context.Context, email string) (entity.User, error) {
 	const method = "service.user.GetUserByEmail"
 
-	user, err := d.storage.GetUserByEmail(ctx, clientID, email)
+	user, err := d.storage.GetUserByEmail(ctx, email)
 	if err != nil {
 		if errors.Is(err, storage.ErrUserNotFound) {
 			return entity.User{}, domain.ErrUserNotFound
@@ -58,10 +58,10 @@ func (d *UserData) GetUserByEmail(ctx context.Context, clientID, email string) (
 	return user, nil
 }
 
-func (d *UserData) GetUserData(ctx context.Context, clientID, userID string) (entity.User, error) {
+func (d *UserData) GetUserData(ctx context.Context, userID string) (entity.User, error) {
 	const method = "service.user.GetUserData"
 
-	user, err := d.storage.GetUserData(ctx, clientID, userID)
+	user, err := d.storage.GetUserData(ctx, userID)
 	if err != nil {
 		if errors.Is(err, storage.ErrUserNotFound) {
 			return entity.User{}, domain.ErrUserNotFound
@@ -85,10 +85,10 @@ func (d *UserData) UpdateUserData(ctx context.Context, user entity.User) error {
 	return nil
 }
 
-func (d *UserData) GetUserStatusByEmail(ctx context.Context, clientID, email string) (string, error) {
+func (d *UserData) GetUserStatusByEmail(ctx context.Context, email string) (string, error) {
 	const method = "service.user.GetUserStatusByEmail"
 
-	status, err := d.storage.GetUserStatusByEmail(ctx, clientID, email)
+	status, err := d.storage.GetUserStatusByEmail(ctx, email)
 	if err != nil {
 		if errors.Is(err, storage.ErrUserNotFound) {
 			return "", domain.ErrUserNotFound
@@ -99,10 +99,10 @@ func (d *UserData) GetUserStatusByEmail(ctx context.Context, clientID, email str
 	return status, nil
 }
 
-func (d *UserData) GetUserStatusByID(ctx context.Context, clientID, userID string) (string, error) {
+func (d *UserData) GetUserStatusByID(ctx context.Context, userID string) (string, error) {
 	const method = "service.user.GetUserStatusByID"
 
-	status, err := d.storage.GetUserStatusByID(ctx, clientID, userID)
+	status, err := d.storage.GetUserStatusByID(ctx, userID)
 	if err != nil {
 		if errors.Is(err, storage.ErrUserNotFound) {
 			return "", domain.ErrUserNotFound

--- a/internal/domain/service/userdata/userdata_service_test.go
+++ b/internal/domain/service/userdata/userdata_service_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestUserDataService_GetUserByID(t *testing.T) {
-	clientID := "test-app-id"
 	userID := "test-user-id"
 
 	tests := []struct {
@@ -29,12 +28,11 @@ func TestUserDataService_GetUserByID(t *testing.T) {
 			mockBehavior: func(userStorage *mocks.Storage) {
 				expectedUser := entity.User{
 					Email:     "test-email@gmail.com",
-					ClientID:  clientID,
 					Verified:  true,
 					UpdatedAt: time.Now(),
 				}
 				userStorage.EXPECT().
-					GetUserByID(context.Background(), clientID, userID).
+					GetUserByID(context.Background(), userID).
 					Return(expectedUser, nil)
 			},
 			expectedError: nil,
@@ -43,7 +41,7 @@ func TestUserDataService_GetUserByID(t *testing.T) {
 			name: "Error - User not found",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserByID(context.Background(), clientID, userID).
+					GetUserByID(context.Background(), userID).
 					Return(entity.User{}, storage.ErrUserNotFound)
 			},
 			expectedError: domain.ErrUserNotFound,
@@ -52,7 +50,7 @@ func TestUserDataService_GetUserByID(t *testing.T) {
 			name: "Error - Storage error",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserByID(context.Background(), clientID, "test-user-id").
+					GetUserByID(context.Background(), "test-user-id").
 					Return(entity.User{}, errors.New("storage error"))
 			},
 			expectedError: errors.New("storage error"),
@@ -65,7 +63,7 @@ func TestUserDataService_GetUserByID(t *testing.T) {
 			tt.mockBehavior(mockStorage)
 
 			service := NewService(mockStorage)
-			user, err := service.GetUserByID(context.Background(), clientID, userID)
+			user, err := service.GetUserByID(context.Background(), userID)
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
@@ -80,7 +78,6 @@ func TestUserDataService_GetUserByID(t *testing.T) {
 }
 
 func TestUserDataService_GetUserByEmail(t *testing.T) {
-	clientID := "test-app-id"
 	email := "test-email@gmail.com"
 
 	tests := []struct {
@@ -93,12 +90,11 @@ func TestUserDataService_GetUserByEmail(t *testing.T) {
 			mockBehavior: func(userStorage *mocks.Storage) {
 				expectedUser := entity.User{
 					Email:     email,
-					ClientID:  clientID,
 					Verified:  true,
 					UpdatedAt: time.Now(),
 				}
 				userStorage.EXPECT().
-					GetUserByEmail(context.Background(), clientID, email).
+					GetUserByEmail(context.Background(), email).
 					Return(expectedUser, nil)
 			},
 			expectedError: nil,
@@ -107,7 +103,7 @@ func TestUserDataService_GetUserByEmail(t *testing.T) {
 			name: "Error - User not found",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserByEmail(context.Background(), clientID, email).
+					GetUserByEmail(context.Background(), email).
 					Return(entity.User{}, storage.ErrUserNotFound)
 			},
 			expectedError: domain.ErrUserNotFound,
@@ -116,7 +112,7 @@ func TestUserDataService_GetUserByEmail(t *testing.T) {
 			name: "Error - Storage error",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserByEmail(context.Background(), clientID, email).
+					GetUserByEmail(context.Background(), email).
 					Return(entity.User{}, errors.New("user storage error"))
 			},
 			expectedError: errors.New("user storage error"),
@@ -129,7 +125,7 @@ func TestUserDataService_GetUserByEmail(t *testing.T) {
 			tt.mockBehavior(mockStorage)
 
 			service := NewService(mockStorage)
-			user, err := service.GetUserByEmail(context.Background(), clientID, email)
+			user, err := service.GetUserByEmail(context.Background(), email)
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
@@ -145,7 +141,6 @@ func TestUserDataService_GetUserByEmail(t *testing.T) {
 
 func TestUserDataService_GetUserData(t *testing.T) {
 	ctx := context.Background()
-	clientID := "test-app-id"
 	userID := "test-user-id"
 
 	tests := []struct {
@@ -156,12 +151,11 @@ func TestUserDataService_GetUserData(t *testing.T) {
 		{
 			name: "Success",
 			mockBehavior: func(userStorage *mocks.Storage) {
-				userStorage.EXPECT().GetUserData(ctx, clientID, userID).
+				userStorage.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{
 						ID:        userID,
 						Email:     "test-email@gmail.com",
-						ClientID:  clientID,
 						Verified:  true,
 						UpdatedAt: time.Now(),
 					}, nil)
@@ -171,7 +165,7 @@ func TestUserDataService_GetUserData(t *testing.T) {
 		{
 			name: "Error – User not found",
 			mockBehavior: func(userStorage *mocks.Storage) {
-				userStorage.EXPECT().GetUserData(ctx, clientID, userID).
+				userStorage.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{}, storage.ErrUserNotFound)
 			},
@@ -180,7 +174,7 @@ func TestUserDataService_GetUserData(t *testing.T) {
 		{
 			name: "Error – Storage error",
 			mockBehavior: func(userStorage *mocks.Storage) {
-				userStorage.EXPECT().GetUserData(ctx, clientID, userID).
+				userStorage.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user storage error"))
 			},
@@ -195,7 +189,7 @@ func TestUserDataService_GetUserData(t *testing.T) {
 
 			service := NewService(mockStorage)
 
-			user, err := service.GetUserData(ctx, clientID, userID)
+			user, err := service.GetUserData(ctx, userID)
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
@@ -214,7 +208,6 @@ func TestUserDataService_UpdateUser(t *testing.T) {
 		ID:           "test-user-id",
 		Email:        "test-email@gmail.com",
 		PasswordHash: "password-hash",
-		ClientID:     "test-client-id",
 	}
 
 	tests := []struct {
@@ -275,7 +268,6 @@ func TestUserDataService_UpdateUser(t *testing.T) {
 
 func TestUserDataService_GetUserStatusByEmail(t *testing.T) {
 	ctx := context.Background()
-	clientID := "test-app-id"
 	email := "email@example.com"
 
 	tests := []struct {
@@ -287,7 +279,7 @@ func TestUserDataService_GetUserStatusByEmail(t *testing.T) {
 			name: "Success",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserStatusByEmail(ctx, clientID, email).
+					GetUserStatusByEmail(ctx, email).
 					Return("active", nil)
 			},
 			expectedError: nil,
@@ -296,7 +288,7 @@ func TestUserDataService_GetUserStatusByEmail(t *testing.T) {
 			name: "Error — User not found",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserStatusByEmail(ctx, clientID, email).
+					GetUserStatusByEmail(ctx, email).
 					Return("", storage.ErrUserNotFound)
 			},
 			expectedError: domain.ErrUserNotFound,
@@ -305,7 +297,7 @@ func TestUserDataService_GetUserStatusByEmail(t *testing.T) {
 			name: "Error - Storage error",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserStatusByEmail(ctx, clientID, email).
+					GetUserStatusByEmail(ctx, email).
 					Return("", errors.New("user storage error"))
 			},
 			expectedError: errors.New("user storage error"),
@@ -321,7 +313,7 @@ func TestUserDataService_GetUserStatusByEmail(t *testing.T) {
 			var status string
 			var err error
 
-			status, err = service.GetUserStatusByEmail(ctx, clientID, email)
+			status, err = service.GetUserStatusByEmail(ctx, email)
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
@@ -337,7 +329,6 @@ func TestUserDataService_GetUserStatusByEmail(t *testing.T) {
 
 func TestUserDataService_GetUserStatusByID(t *testing.T) {
 	ctx := context.Background()
-	clientID := "test-app-id"
 	userID := "test-user-id"
 
 	tests := []struct {
@@ -349,7 +340,7 @@ func TestUserDataService_GetUserStatusByID(t *testing.T) {
 			name: "Success",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserStatusByID(ctx, clientID, userID).
+					GetUserStatusByID(ctx, userID).
 					Return("active", nil)
 			},
 			expectedError: nil,
@@ -358,7 +349,7 @@ func TestUserDataService_GetUserStatusByID(t *testing.T) {
 			name: "Error — User not found",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserStatusByID(ctx, clientID, userID).
+					GetUserStatusByID(ctx, userID).
 					Return("", storage.ErrUserNotFound)
 			},
 			expectedError: domain.ErrUserNotFound,
@@ -367,7 +358,7 @@ func TestUserDataService_GetUserStatusByID(t *testing.T) {
 			name: "Error - Storage error",
 			mockBehavior: func(userStorage *mocks.Storage) {
 				userStorage.EXPECT().
-					GetUserStatusByID(ctx, clientID, userID).
+					GetUserStatusByID(ctx, userID).
 					Return("", errors.New("user storage error"))
 			},
 			expectedError: errors.New("user storage error"),
@@ -383,7 +374,7 @@ func TestUserDataService_GetUserStatusByID(t *testing.T) {
 			var status string
 			var err error
 
-			status, err = service.GetUserStatusByID(ctx, clientID, userID)
+			status, err = service.GetUserStatusByID(ctx, userID)
 
 			if tt.expectedError != nil {
 				require.Error(t, err)
@@ -400,7 +391,6 @@ func TestUserDataService_GetUserStatusByID(t *testing.T) {
 func TestUserDataService_DeleteUser(t *testing.T) {
 	deletedUser := entity.User{
 		ID:        "test-user-id",
-		ClientID:  "test-client-id",
 		DeletedAt: time.Now(),
 	}
 

--- a/internal/domain/service/verification/mocks/mock_Storage.go
+++ b/internal/domain/service/verification/mocks/mock_Storage.go
@@ -22,17 +22,17 @@ func (_m *Storage) EXPECT() *Storage_Expecter {
 	return &Storage_Expecter{mock: &_m.Mock}
 }
 
-// DeleteAllTokens provides a mock function with given fields: ctx, clientID, userID
-func (_m *Storage) DeleteAllTokens(ctx context.Context, clientID string, userID string) error {
-	ret := _m.Called(ctx, clientID, userID)
+// DeleteAllTokens provides a mock function with given fields: ctx, userID
+func (_m *Storage) DeleteAllTokens(ctx context.Context, userID string) error {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAllTokens")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -47,15 +47,14 @@ type Storage_DeleteAllTokens_Call struct {
 
 // DeleteAllTokens is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *Storage_Expecter) DeleteAllTokens(ctx interface{}, clientID interface{}, userID interface{}) *Storage_DeleteAllTokens_Call {
-	return &Storage_DeleteAllTokens_Call{Call: _e.mock.On("DeleteAllTokens", ctx, clientID, userID)}
+func (_e *Storage_Expecter) DeleteAllTokens(ctx interface{}, userID interface{}) *Storage_DeleteAllTokens_Call {
+	return &Storage_DeleteAllTokens_Call{Call: _e.mock.On("DeleteAllTokens", ctx, userID)}
 }
 
-func (_c *Storage_DeleteAllTokens_Call) Run(run func(ctx context.Context, clientID string, userID string)) *Storage_DeleteAllTokens_Call {
+func (_c *Storage_DeleteAllTokens_Call) Run(run func(ctx context.Context, userID string)) *Storage_DeleteAllTokens_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -65,7 +64,7 @@ func (_c *Storage_DeleteAllTokens_Call) Return(_a0 error) *Storage_DeleteAllToke
 	return _c
 }
 
-func (_c *Storage_DeleteAllTokens_Call) RunAndReturn(run func(context.Context, string, string) error) *Storage_DeleteAllTokens_Call {
+func (_c *Storage_DeleteAllTokens_Call) RunAndReturn(run func(context.Context, string) error) *Storage_DeleteAllTokens_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/service/verification/verification_service.go
+++ b/internal/domain/service/verification/verification_service.go
@@ -22,7 +22,7 @@ type Storage interface {
 	SaveVerificationToken(ctx context.Context, data entity.VerificationToken) error
 	GetVerificationTokenData(ctx context.Context, token string) (entity.VerificationToken, error)
 	DeleteVerificationToken(ctx context.Context, token string) error
-	DeleteAllTokens(ctx context.Context, clientID, userID string) error
+	DeleteAllTokens(ctx context.Context, userID string) error
 }
 
 func NewService(tokenExpiryTime time.Duration, storage Storage) *Service {
@@ -82,10 +82,10 @@ func (s *Service) DeleteToken(ctx context.Context, token string) error {
 	return nil
 }
 
-func (s *Service) DeleteAllTokens(ctx context.Context, clientID, userID string) error {
+func (s *Service) DeleteAllTokens(ctx context.Context, userID string) error {
 	const method = "service.verification.DeleteAllTokens"
 
-	if err := s.storage.DeleteAllTokens(ctx, clientID, userID); err != nil {
+	if err := s.storage.DeleteAllTokens(ctx, userID); err != nil {
 		return fmt.Errorf("%s: %w: %w", method, domain.ErrFailedToDeleteAllVerificationTokens, err)
 	}
 

--- a/internal/domain/service/verification/verification_service_test.go
+++ b/internal/domain/service/verification/verification_service_test.go
@@ -32,7 +32,7 @@ func TestVerificationService_CreateToken(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "Error – Failed to save verification token",
+			name: "Error - Failed to save verification token",
 			mockBehavior: func(verificationStorage *mocks.Storage) {
 				verificationStorage.EXPECT().SaveVerificationToken(ctx, mock.AnythingOfType("entity.VerificationToken")).
 					Once().
@@ -45,9 +45,8 @@ func TestVerificationService_CreateToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			user := entity.User{
-				ID:       "test-user-id",
-				ClientID: "test-client-id",
-				Email:    "test-email@gmail.com",
+				ID:    "test-user-id",
+				Email: "test-email@gmail.com",
 			}
 			tokenType := entity.TokenTypeVerifyEmail
 			verificationEndpoint := "https://example.com/verify"
@@ -81,7 +80,6 @@ func TestVerificationService_GetTokenData(t *testing.T) {
 	verificationToken := entity.VerificationToken{
 		Token:    tokenStr,
 		UserID:   "test-user-id",
-		ClientID: "test-client-id",
 		Endpoint: "https://example.com/verify",
 		Email:    "test-email@gmail.com",
 		Type:     entity.TokenTypeVerifyEmail,
@@ -102,7 +100,7 @@ func TestVerificationService_GetTokenData(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "Error – Token not found",
+			name: "Error - Token not found",
 			mockBehavior: func(verificationStorage *mocks.Storage) {
 				verificationStorage.EXPECT().GetVerificationTokenData(ctx, tokenStr).
 					Once().
@@ -111,7 +109,7 @@ func TestVerificationService_GetTokenData(t *testing.T) {
 			expectedError: domain.ErrVerificationTokenNotFound,
 		},
 		{
-			name: "Error – Failed to get verification token data",
+			name: "Error - Failed to get verification token data",
 			mockBehavior: func(verificationStorage *mocks.Storage) {
 				verificationStorage.EXPECT().GetVerificationTokenData(ctx, tokenStr).
 					Once().
@@ -162,7 +160,7 @@ func TestVerificationService_DeleteToken(t *testing.T) {
 			expectedError: nil,
 		},
 		{
-			name: "Error – Failed to delete verification token",
+			name: "Error - Failed to delete verification token",
 			mockBehavior: func(mockVerificationStorage *mocks.Storage) {
 				mockVerificationStorage.EXPECT().DeleteVerificationToken(ctx, tokenStr).
 					Once().
@@ -193,7 +191,6 @@ func TestVerificationService_DeleteToken(t *testing.T) {
 }
 
 func TestVerificationService_DeleteAllTokens(t *testing.T) {
-	clientID := "test-app-id"
 	userID := "test-user-id"
 
 	tests := []struct {
@@ -205,7 +202,7 @@ func TestVerificationService_DeleteAllTokens(t *testing.T) {
 			name: "Success",
 			mockBehavior: func(verificationStorage *mocks.Storage) {
 				verificationStorage.EXPECT().
-					DeleteAllTokens(context.Background(), clientID, userID).
+					DeleteAllTokens(context.Background(), userID).
 					Return(nil)
 			},
 			expectedError: nil,
@@ -214,7 +211,7 @@ func TestVerificationService_DeleteAllTokens(t *testing.T) {
 			name: "Error - Storage error",
 			mockBehavior: func(verificationStorage *mocks.Storage) {
 				verificationStorage.EXPECT().
-					DeleteAllTokens(context.Background(), clientID, userID).
+					DeleteAllTokens(context.Background(), userID).
 					Return(errors.New("verification storage error"))
 			},
 			expectedError: errors.New("verification storage error"),
@@ -229,7 +226,7 @@ func TestVerificationService_DeleteAllTokens(t *testing.T) {
 			tokenExpiryTime := 24 * time.Hour
 			verificationService := NewService(tokenExpiryTime, mockVerificationStorage)
 
-			err := verificationService.DeleteAllTokens(context.Background(), clientID, userID)
+			err := verificationService.DeleteAllTokens(context.Background(), userID)
 
 			if tt.expectedError != nil {
 				require.Error(t, err)

--- a/internal/domain/usecase/auth/auth_usecase_test.go
+++ b/internal/domain/usecase/auth/auth_usecase_test.go
@@ -38,7 +38,6 @@ func TestAuthUsecase_Login(t *testing.T) {
 		ID:           userID,
 		Email:        email,
 		PasswordHash: hashedPassword,
-		ClientID:     clientID,
 	}
 
 	validReqData := &entity.UserRequestData{
@@ -76,11 +75,11 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(validUser, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(validUser, nil)
 
@@ -114,7 +113,7 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(entity.User{}, domain.ErrUserNotFound)
 			},
@@ -130,7 +129,7 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user manager error"))
 			},
@@ -146,11 +145,11 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(validUser, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(validUser, nil)
 
@@ -170,11 +169,11 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(validUser, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user manager error"))
 			},
@@ -190,11 +189,11 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(validUser, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(validUser, nil)
 
@@ -214,11 +213,11 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(validUser, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(validUser, nil)
 
@@ -252,11 +251,11 @@ func TestAuthUsecase_Login(t *testing.T) {
 				sessionMgr *mocks.SessionManager,
 				txMgr *mocks.TransactionManager,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserByEmail(ctx, email).
 					Once().
 					Return(validUser, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(validUser, nil)
 
@@ -371,13 +370,12 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return(entity.UserStatusNotFound.String(), nil)
 
 				storage.EXPECT().RegisterUser(ctx, mock.MatchedBy(func(user entity.User) bool {
 					return user.Email == email &&
-						user.ClientID == clientID &&
 						user.PasswordHash == hashedPassword
 				})).
 					Once().
@@ -420,13 +418,12 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return(entity.UserStatusSoftDeleted.String(), nil)
 
 				storage.EXPECT().ReplaceSoftDeletedUser(ctx, mock.MatchedBy(func(user entity.User) bool {
 					return user.Email == email &&
-						user.ClientID == clientID &&
 						user.PasswordHash == hashedPassword
 				})).
 					Once().
@@ -469,7 +466,7 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 			},
@@ -518,7 +515,7 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return("", fmt.Errorf("user manager error"))
 			},
@@ -547,7 +544,7 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return(entity.UserStatusSoftDeleted.String(), nil)
 
@@ -580,7 +577,7 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return(entity.UserStatusNotFound.String(), nil)
 
@@ -613,7 +610,7 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return("some unknown user status", nil)
 			},
@@ -642,13 +639,12 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, "test@example.com").
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, "test@example.com").
 					Once().
 					Return(entity.UserStatusNotFound.String(), nil)
 
 				storage.EXPECT().RegisterUser(ctx, mock.MatchedBy(func(user entity.User) bool {
 					return user.Email == email &&
-						user.ClientID == clientID &&
 						user.PasswordHash == hashedPassword
 				})).
 					Once().
@@ -683,13 +679,12 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, email).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, email).
 					Once().
 					Return(entity.UserStatusNotFound.String(), nil)
 
 				storage.EXPECT().RegisterUser(ctx, mock.MatchedBy(func(user entity.User) bool {
 					return user.Email == email &&
-						user.ClientID == clientID &&
 						user.PasswordHash == hashedPassword
 				})).
 					Once().
@@ -728,13 +723,12 @@ func TestAuthUsecase_RegisterUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, "test@example.com").
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, "test@example.com").
 					Once().
 					Return(entity.UserStatusNotFound.String(), nil)
 
 				storage.EXPECT().RegisterUser(ctx, mock.MatchedBy(func(user entity.User) bool {
 					return user.Email == email &&
-						user.ClientID == clientID &&
 						user.PasswordHash == hashedPassword
 				})).
 					Once().
@@ -814,22 +808,19 @@ func TestAuthUsecase_VerifyEmail(t *testing.T) {
 	ctx := context.Background()
 
 	userID := "test-user-id"
-	clientID := "test-client-id"
 	endpoint := "https://example.com/verify"
 	email := "test@example.com"
 	tokenStr := "test-verification-token"
 	tokenType := entity.TokenTypeVerifyEmail
 
 	userData := entity.User{
-		ID:       "test-user-id",
-		ClientID: "test-client-id",
-		Email:    "test@example.com",
+		ID:    "test-user-id",
+		Email: "test@example.com",
 	}
 
 	expectedTokenData := entity.VerificationToken{
 		Token:     tokenStr,
 		UserID:    userID,
-		ClientID:  clientID,
 		Endpoint:  endpoint,
 		Email:     email,
 		Type:      tokenType,
@@ -839,7 +830,6 @@ func TestAuthUsecase_VerifyEmail(t *testing.T) {
 	expiredTokenData := entity.VerificationToken{
 		Token:     tokenStr,
 		UserID:    userID,
-		ClientID:  clientID,
 		Endpoint:  endpoint,
 		Email:     email,
 		Type:      tokenType,
@@ -849,7 +839,6 @@ func TestAuthUsecase_VerifyEmail(t *testing.T) {
 	newTokenData := entity.VerificationToken{
 		Token:     "new-test-verification-token",
 		UserID:    userID,
-		ClientID:  clientID,
 		Endpoint:  endpoint,
 		Email:     email,
 		Type:      tokenType,
@@ -883,7 +872,7 @@ func TestAuthUsecase_VerifyEmail(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				storage.EXPECT().MarkEmailVerified(ctx, expectedTokenData.UserID, expectedTokenData.ClientID).
+				storage.EXPECT().MarkEmailVerified(ctx, expectedTokenData.UserID).
 					Once().
 					Return(nil)
 			},
@@ -1056,7 +1045,7 @@ func TestAuthUsecase_VerifyEmail(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				storage.EXPECT().MarkEmailVerified(ctx, expectedTokenData.UserID, expectedTokenData.ClientID).
+				storage.EXPECT().MarkEmailVerified(ctx, expectedTokenData.UserID).
 					Once().
 					Return(fmt.Errorf("storage error"))
 			},
@@ -1113,7 +1102,6 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 
 	userData := entity.User{
 		ID:        "test-user-id",
-		ClientID:  clientID,
 		Email:     "test@example.com",
 		UpdatedAt: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
@@ -1125,7 +1113,6 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 	expectedTokenData := entity.VerificationToken{
 		Token:     tokenStr,
 		UserID:    userData.ID,
-		ClientID:  userData.ClientID,
 		Endpoint:  endpoint,
 		Email:     userData.Email,
 		Type:      tokenType,
@@ -1148,7 +1135,7 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 				verificationMgr *mocks.VerificationManager,
 				mailService *mocks.MailService,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, reqData.Email).
+				userMgr.EXPECT().GetUserByEmail(ctx, reqData.Email).
 					Once().
 					Return(userData, nil)
 
@@ -1169,7 +1156,7 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 				verificationMgr *mocks.VerificationManager,
 				mailService *mocks.MailService,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, reqData.Email).
+				userMgr.EXPECT().GetUserByEmail(ctx, reqData.Email).
 					Once().
 					Return(entity.User{}, storage.ErrUserNotFound)
 			},
@@ -1182,7 +1169,7 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 				verificationMgr *mocks.VerificationManager,
 				mailService *mocks.MailService,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, reqData.Email).
+				userMgr.EXPECT().GetUserByEmail(ctx, reqData.Email).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user manager error"))
 			},
@@ -1195,7 +1182,7 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 				verificationMgr *mocks.VerificationManager,
 				mailService *mocks.MailService,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, reqData.Email).
+				userMgr.EXPECT().GetUserByEmail(ctx, reqData.Email).
 					Once().
 					Return(userData, nil)
 
@@ -1212,7 +1199,7 @@ func TestAuthUsecase_ResetPassword(t *testing.T) {
 				verificationMgr *mocks.VerificationManager,
 				mailService *mocks.MailService,
 			) {
-				userMgr.EXPECT().GetUserByEmail(ctx, clientID, reqData.Email).
+				userMgr.EXPECT().GetUserByEmail(ctx, reqData.Email).
 					Once().
 					Return(userData, nil)
 
@@ -1258,7 +1245,6 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 
 	userData := entity.User{
 		ID:        userID,
-		ClientID:  clientID,
 		Email:     "email@example.com",
 		UpdatedAt: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}
@@ -1279,7 +1265,6 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 	expectedTokenData := entity.VerificationToken{
 		Token:     tokenStr,
 		UserID:    userData.ID,
-		ClientID:  userData.ClientID,
 		Endpoint:  endpoint,
 		Email:     userData.Email,
 		Type:      tokenType,
@@ -1289,7 +1274,6 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 	expiredTokenData := entity.VerificationToken{
 		Token:     tokenStr,
 		UserID:    userData.ID,
-		ClientID:  userData.ClientID,
 		Endpoint:  endpoint,
 		Email:     userData.Email,
 		Type:      tokenType,
@@ -1299,7 +1283,6 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 	newTokenData := entity.VerificationToken{
 		Token:     "new-test-verification-token",
 		UserID:    userData.ID,
-		ClientID:  userData.ClientID,
 		Endpoint:  endpoint,
 		Email:     userData.Email,
 		Type:      tokenType,
@@ -1335,13 +1318,12 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{
 						ID:           userData.ID,
 						Email:        userData.Email,
 						PasswordHash: hashedPassword,
-						ClientID:     userData.ClientID,
 						UpdatedAt:    time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 					}, nil)
 
@@ -1355,8 +1337,7 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 
 				userMgr.EXPECT().UpdateUserData(ctx, mock.MatchedBy(func(u entity.User) bool {
 					return u.ID == userData.ID &&
-						u.PasswordHash == newPasswordHash &&
-						u.ClientID == userData.ClientID
+						u.PasswordHash == newPasswordHash
 				})).
 					Once().
 					Return(nil)
@@ -1517,7 +1498,7 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user manager error"))
 			},
@@ -1541,13 +1522,12 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{
 						ID:           userData.ID,
 						Email:        userData.Email,
 						PasswordHash: hashedPassword,
-						ClientID:     userData.ClientID,
 						UpdatedAt:    time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 					}, nil)
 
@@ -1575,13 +1555,12 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{
 						ID:           userData.ID,
 						Email:        userData.Email,
 						PasswordHash: hashedPassword,
-						ClientID:     userData.ClientID,
 						UpdatedAt:    time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 					}, nil)
 
@@ -1609,13 +1588,12 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{
 						ID:           userData.ID,
 						Email:        userData.Email,
 						PasswordHash: hashedPassword,
-						ClientID:     userData.ClientID,
 						UpdatedAt:    time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 					}, nil)
 
@@ -1647,13 +1625,12 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 					Once().
 					Return(expectedTokenData, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{
 						ID:           userData.ID,
 						Email:        userData.Email,
 						PasswordHash: hashedPassword,
-						ClientID:     userData.ClientID,
 						UpdatedAt:    time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
 					}, nil)
 
@@ -1667,8 +1644,7 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 
 				userMgr.EXPECT().UpdateUserData(ctx, mock.MatchedBy(func(u entity.User) bool {
 					return u.ID == userData.ID &&
-						u.PasswordHash == newPasswordHash &&
-						u.ClientID == userData.ClientID
+						u.PasswordHash == newPasswordHash
 				})).
 					Once().
 					Return(fmt.Errorf("user manager error"))
@@ -1707,7 +1683,7 @@ func TestAuthUsecase_ChangePassword(t *testing.T) {
 
 			auth := NewUsecase(log, nil, userMgr, mailService, tokenMgr, verificationMgr, txMgr, nil)
 
-			_, err := auth.ChangePassword(ctx, userData.ClientID, reqData)
+			_, err := auth.ChangePassword(ctx, clientID, reqData)
 
 			if tt.expectedError != nil {
 				assert.Contains(t, err.Error(), tt.expectedError.Error())
@@ -1744,7 +1720,7 @@ func TestAuthUsecase_LogoutUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return(deviceID, nil)
 
@@ -1775,7 +1751,7 @@ func TestAuthUsecase_LogoutUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return("", domain.ErrUserDeviceNotFound)
 			},
@@ -1788,7 +1764,7 @@ func TestAuthUsecase_LogoutUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return("", fmt.Errorf("session manager error"))
 			},
@@ -1801,7 +1777,7 @@ func TestAuthUsecase_LogoutUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return(deviceID, nil)
 
@@ -1871,7 +1847,6 @@ func TestAuthUsecase_RefreshTokens(t *testing.T) {
 
 	userSession := entity.Session{
 		UserID:        userID,
-		ClientID:      clientID,
 		DeviceID:      deviceID,
 		RefreshToken:  refreshTokenStr,
 		LastVisitedAt: time.Now(),
@@ -1903,7 +1878,7 @@ func TestAuthUsecase_RefreshTokens(t *testing.T) {
 					Once().
 					Return(userSession, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return(deviceID, nil)
 
@@ -1945,7 +1920,7 @@ func TestAuthUsecase_RefreshTokens(t *testing.T) {
 					Once().
 					Return(userSession, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return("", domain.ErrUserDeviceNotFound)
 			},
@@ -1969,7 +1944,7 @@ func TestAuthUsecase_RefreshTokens(t *testing.T) {
 					Once().
 					Return(userSession, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return(deviceID, nil)
 
@@ -1987,7 +1962,7 @@ func TestAuthUsecase_RefreshTokens(t *testing.T) {
 					Once().
 					Return(userSession, nil)
 
-				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, clientID, userAgent).
+				sessionMgr.EXPECT().GetUserDeviceID(ctx, userID, userAgent).
 					Once().
 					Return(deviceID, nil)
 

--- a/internal/domain/usecase/auth/mocks/mock_SessionManager.go
+++ b/internal/domain/usecase/auth/mocks/mock_SessionManager.go
@@ -230,9 +230,9 @@ func (_c *SessionManager_GetSessionByRefreshToken_Call) RunAndReturn(run func(co
 	return _c
 }
 
-// GetUserDeviceID provides a mock function with given fields: ctx, userID, clientID, userAgent
-func (_m *SessionManager) GetUserDeviceID(ctx context.Context, userID string, clientID string, userAgent string) (string, error) {
-	ret := _m.Called(ctx, userID, clientID, userAgent)
+// GetUserDeviceID provides a mock function with given fields: ctx, userID, userAgent
+func (_m *SessionManager) GetUserDeviceID(ctx context.Context, userID string, userAgent string) (string, error) {
+	ret := _m.Called(ctx, userID, userAgent)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserDeviceID")
@@ -240,17 +240,17 @@ func (_m *SessionManager) GetUserDeviceID(ctx context.Context, userID string, cl
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) (string, error)); ok {
-		return rf(ctx, userID, clientID, userAgent)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
+		return rf(ctx, userID, userAgent)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) string); ok {
-		r0 = rf(ctx, userID, clientID, userAgent)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
+		r0 = rf(ctx, userID, userAgent)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, userID, clientID, userAgent)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, userID, userAgent)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -266,15 +266,14 @@ type SessionManager_GetUserDeviceID_Call struct {
 // GetUserDeviceID is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userID string
-//   - clientID string
 //   - userAgent string
-func (_e *SessionManager_Expecter) GetUserDeviceID(ctx interface{}, userID interface{}, clientID interface{}, userAgent interface{}) *SessionManager_GetUserDeviceID_Call {
-	return &SessionManager_GetUserDeviceID_Call{Call: _e.mock.On("GetUserDeviceID", ctx, userID, clientID, userAgent)}
+func (_e *SessionManager_Expecter) GetUserDeviceID(ctx interface{}, userID interface{}, userAgent interface{}) *SessionManager_GetUserDeviceID_Call {
+	return &SessionManager_GetUserDeviceID_Call{Call: _e.mock.On("GetUserDeviceID", ctx, userID, userAgent)}
 }
 
-func (_c *SessionManager_GetUserDeviceID_Call) Run(run func(ctx context.Context, userID string, clientID string, userAgent string)) *SessionManager_GetUserDeviceID_Call {
+func (_c *SessionManager_GetUserDeviceID_Call) Run(run func(ctx context.Context, userID string, userAgent string)) *SessionManager_GetUserDeviceID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -284,7 +283,7 @@ func (_c *SessionManager_GetUserDeviceID_Call) Return(_a0 string, _a1 error) *Se
 	return _c
 }
 
-func (_c *SessionManager_GetUserDeviceID_Call) RunAndReturn(run func(context.Context, string, string, string) (string, error)) *SessionManager_GetUserDeviceID_Call {
+func (_c *SessionManager_GetUserDeviceID_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *SessionManager_GetUserDeviceID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/usecase/auth/mocks/mock_Storage.go
+++ b/internal/domain/usecase/auth/mocks/mock_Storage.go
@@ -22,17 +22,17 @@ func (_m *Storage) EXPECT() *Storage_Expecter {
 	return &Storage_Expecter{mock: &_m.Mock}
 }
 
-// MarkEmailVerified provides a mock function with given fields: ctx, userID, clientID
-func (_m *Storage) MarkEmailVerified(ctx context.Context, userID string, clientID string) error {
-	ret := _m.Called(ctx, userID, clientID)
+// MarkEmailVerified provides a mock function with given fields: ctx, userID
+func (_m *Storage) MarkEmailVerified(ctx context.Context, userID string) error {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MarkEmailVerified")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, userID, clientID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -48,14 +48,13 @@ type Storage_MarkEmailVerified_Call struct {
 // MarkEmailVerified is a helper method to define mock.On call
 //   - ctx context.Context
 //   - userID string
-//   - clientID string
-func (_e *Storage_Expecter) MarkEmailVerified(ctx interface{}, userID interface{}, clientID interface{}) *Storage_MarkEmailVerified_Call {
-	return &Storage_MarkEmailVerified_Call{Call: _e.mock.On("MarkEmailVerified", ctx, userID, clientID)}
+func (_e *Storage_Expecter) MarkEmailVerified(ctx interface{}, userID interface{}) *Storage_MarkEmailVerified_Call {
+	return &Storage_MarkEmailVerified_Call{Call: _e.mock.On("MarkEmailVerified", ctx, userID)}
 }
 
-func (_c *Storage_MarkEmailVerified_Call) Run(run func(ctx context.Context, userID string, clientID string)) *Storage_MarkEmailVerified_Call {
+func (_c *Storage_MarkEmailVerified_Call) Run(run func(ctx context.Context, userID string)) *Storage_MarkEmailVerified_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -65,7 +64,7 @@ func (_c *Storage_MarkEmailVerified_Call) Return(_a0 error) *Storage_MarkEmailVe
 	return _c
 }
 
-func (_c *Storage_MarkEmailVerified_Call) RunAndReturn(run func(context.Context, string, string) error) *Storage_MarkEmailVerified_Call {
+func (_c *Storage_MarkEmailVerified_Call) RunAndReturn(run func(context.Context, string) error) *Storage_MarkEmailVerified_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/usecase/auth/mocks/mock_UserdataManager.go
+++ b/internal/domain/usecase/auth/mocks/mock_UserdataManager.go
@@ -22,9 +22,9 @@ func (_m *UserdataManager) EXPECT() *UserdataManager_Expecter {
 	return &UserdataManager_Expecter{mock: &_m.Mock}
 }
 
-// GetUserByEmail provides a mock function with given fields: ctx, clientID, email
-func (_m *UserdataManager) GetUserByEmail(ctx context.Context, clientID string, email string) (entity.User, error) {
-	ret := _m.Called(ctx, clientID, email)
+// GetUserByEmail provides a mock function with given fields: ctx, email
+func (_m *UserdataManager) GetUserByEmail(ctx context.Context, email string) (entity.User, error) {
+	ret := _m.Called(ctx, email)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserByEmail")
@@ -32,17 +32,17 @@ func (_m *UserdataManager) GetUserByEmail(ctx context.Context, clientID string, 
 
 	var r0 entity.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (entity.User, error)); ok {
-		return rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (entity.User, error)); ok {
+		return rf(ctx, email)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) entity.User); ok {
-		r0 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) entity.User); ok {
+		r0 = rf(ctx, email)
 	} else {
 		r0 = ret.Get(0).(entity.User)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, email)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -57,15 +57,14 @@ type UserdataManager_GetUserByEmail_Call struct {
 
 // GetUserByEmail is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - email string
-func (_e *UserdataManager_Expecter) GetUserByEmail(ctx interface{}, clientID interface{}, email interface{}) *UserdataManager_GetUserByEmail_Call {
-	return &UserdataManager_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", ctx, clientID, email)}
+func (_e *UserdataManager_Expecter) GetUserByEmail(ctx interface{}, email interface{}) *UserdataManager_GetUserByEmail_Call {
+	return &UserdataManager_GetUserByEmail_Call{Call: _e.mock.On("GetUserByEmail", ctx, email)}
 }
 
-func (_c *UserdataManager_GetUserByEmail_Call) Run(run func(ctx context.Context, clientID string, email string)) *UserdataManager_GetUserByEmail_Call {
+func (_c *UserdataManager_GetUserByEmail_Call) Run(run func(ctx context.Context, email string)) *UserdataManager_GetUserByEmail_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -75,14 +74,14 @@ func (_c *UserdataManager_GetUserByEmail_Call) Return(_a0 entity.User, _a1 error
 	return _c
 }
 
-func (_c *UserdataManager_GetUserByEmail_Call) RunAndReturn(run func(context.Context, string, string) (entity.User, error)) *UserdataManager_GetUserByEmail_Call {
+func (_c *UserdataManager_GetUserByEmail_Call) RunAndReturn(run func(context.Context, string) (entity.User, error)) *UserdataManager_GetUserByEmail_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserData provides a mock function with given fields: ctx, clientID, userID
-func (_m *UserdataManager) GetUserData(ctx context.Context, clientID string, userID string) (entity.User, error) {
-	ret := _m.Called(ctx, clientID, userID)
+// GetUserData provides a mock function with given fields: ctx, userID
+func (_m *UserdataManager) GetUserData(ctx context.Context, userID string) (entity.User, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserData")
@@ -90,17 +89,17 @@ func (_m *UserdataManager) GetUserData(ctx context.Context, clientID string, use
 
 	var r0 entity.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (entity.User, error)); ok {
-		return rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (entity.User, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) entity.User); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) entity.User); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Get(0).(entity.User)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -115,15 +114,14 @@ type UserdataManager_GetUserData_Call struct {
 
 // GetUserData is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *UserdataManager_Expecter) GetUserData(ctx interface{}, clientID interface{}, userID interface{}) *UserdataManager_GetUserData_Call {
-	return &UserdataManager_GetUserData_Call{Call: _e.mock.On("GetUserData", ctx, clientID, userID)}
+func (_e *UserdataManager_Expecter) GetUserData(ctx interface{}, userID interface{}) *UserdataManager_GetUserData_Call {
+	return &UserdataManager_GetUserData_Call{Call: _e.mock.On("GetUserData", ctx, userID)}
 }
 
-func (_c *UserdataManager_GetUserData_Call) Run(run func(ctx context.Context, clientID string, userID string)) *UserdataManager_GetUserData_Call {
+func (_c *UserdataManager_GetUserData_Call) Run(run func(ctx context.Context, userID string)) *UserdataManager_GetUserData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -133,14 +131,14 @@ func (_c *UserdataManager_GetUserData_Call) Return(_a0 entity.User, _a1 error) *
 	return _c
 }
 
-func (_c *UserdataManager_GetUserData_Call) RunAndReturn(run func(context.Context, string, string) (entity.User, error)) *UserdataManager_GetUserData_Call {
+func (_c *UserdataManager_GetUserData_Call) RunAndReturn(run func(context.Context, string) (entity.User, error)) *UserdataManager_GetUserData_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserStatusByEmail provides a mock function with given fields: ctx, clientID, email
-func (_m *UserdataManager) GetUserStatusByEmail(ctx context.Context, clientID string, email string) (string, error) {
-	ret := _m.Called(ctx, clientID, email)
+// GetUserStatusByEmail provides a mock function with given fields: ctx, email
+func (_m *UserdataManager) GetUserStatusByEmail(ctx context.Context, email string) (string, error) {
+	ret := _m.Called(ctx, email)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserStatusByEmail")
@@ -148,17 +146,17 @@ func (_m *UserdataManager) GetUserStatusByEmail(ctx context.Context, clientID st
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
-		return rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, email)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, email)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, email)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -173,15 +171,14 @@ type UserdataManager_GetUserStatusByEmail_Call struct {
 
 // GetUserStatusByEmail is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - email string
-func (_e *UserdataManager_Expecter) GetUserStatusByEmail(ctx interface{}, clientID interface{}, email interface{}) *UserdataManager_GetUserStatusByEmail_Call {
-	return &UserdataManager_GetUserStatusByEmail_Call{Call: _e.mock.On("GetUserStatusByEmail", ctx, clientID, email)}
+func (_e *UserdataManager_Expecter) GetUserStatusByEmail(ctx interface{}, email interface{}) *UserdataManager_GetUserStatusByEmail_Call {
+	return &UserdataManager_GetUserStatusByEmail_Call{Call: _e.mock.On("GetUserStatusByEmail", ctx, email)}
 }
 
-func (_c *UserdataManager_GetUserStatusByEmail_Call) Run(run func(ctx context.Context, clientID string, email string)) *UserdataManager_GetUserStatusByEmail_Call {
+func (_c *UserdataManager_GetUserStatusByEmail_Call) Run(run func(ctx context.Context, email string)) *UserdataManager_GetUserStatusByEmail_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -191,7 +188,7 @@ func (_c *UserdataManager_GetUserStatusByEmail_Call) Return(_a0 string, _a1 erro
 	return _c
 }
 
-func (_c *UserdataManager_GetUserStatusByEmail_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *UserdataManager_GetUserStatusByEmail_Call {
+func (_c *UserdataManager_GetUserStatusByEmail_Call) RunAndReturn(run func(context.Context, string) (string, error)) *UserdataManager_GetUserStatusByEmail_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/usecase/user/mocks/mock_UserdataManager.go
+++ b/internal/domain/usecase/user/mocks/mock_UserdataManager.go
@@ -69,9 +69,9 @@ func (_c *UserdataManager_DeleteUser_Call) RunAndReturn(run func(context.Context
 	return _c
 }
 
-// GetUserByID provides a mock function with given fields: ctx, clientID, userID
-func (_m *UserdataManager) GetUserByID(ctx context.Context, clientID string, userID string) (entity.User, error) {
-	ret := _m.Called(ctx, clientID, userID)
+// GetUserByID provides a mock function with given fields: ctx, userID
+func (_m *UserdataManager) GetUserByID(ctx context.Context, userID string) (entity.User, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserByID")
@@ -79,17 +79,17 @@ func (_m *UserdataManager) GetUserByID(ctx context.Context, clientID string, use
 
 	var r0 entity.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (entity.User, error)); ok {
-		return rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (entity.User, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) entity.User); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) entity.User); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Get(0).(entity.User)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -104,15 +104,14 @@ type UserdataManager_GetUserByID_Call struct {
 
 // GetUserByID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *UserdataManager_Expecter) GetUserByID(ctx interface{}, clientID interface{}, userID interface{}) *UserdataManager_GetUserByID_Call {
-	return &UserdataManager_GetUserByID_Call{Call: _e.mock.On("GetUserByID", ctx, clientID, userID)}
+func (_e *UserdataManager_Expecter) GetUserByID(ctx interface{}, userID interface{}) *UserdataManager_GetUserByID_Call {
+	return &UserdataManager_GetUserByID_Call{Call: _e.mock.On("GetUserByID", ctx, userID)}
 }
 
-func (_c *UserdataManager_GetUserByID_Call) Run(run func(ctx context.Context, clientID string, userID string)) *UserdataManager_GetUserByID_Call {
+func (_c *UserdataManager_GetUserByID_Call) Run(run func(ctx context.Context, userID string)) *UserdataManager_GetUserByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -122,14 +121,14 @@ func (_c *UserdataManager_GetUserByID_Call) Return(_a0 entity.User, _a1 error) *
 	return _c
 }
 
-func (_c *UserdataManager_GetUserByID_Call) RunAndReturn(run func(context.Context, string, string) (entity.User, error)) *UserdataManager_GetUserByID_Call {
+func (_c *UserdataManager_GetUserByID_Call) RunAndReturn(run func(context.Context, string) (entity.User, error)) *UserdataManager_GetUserByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserData provides a mock function with given fields: ctx, clientID, userID
-func (_m *UserdataManager) GetUserData(ctx context.Context, clientID string, userID string) (entity.User, error) {
-	ret := _m.Called(ctx, clientID, userID)
+// GetUserData provides a mock function with given fields: ctx, userID
+func (_m *UserdataManager) GetUserData(ctx context.Context, userID string) (entity.User, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserData")
@@ -137,17 +136,17 @@ func (_m *UserdataManager) GetUserData(ctx context.Context, clientID string, use
 
 	var r0 entity.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (entity.User, error)); ok {
-		return rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (entity.User, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) entity.User); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) entity.User); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Get(0).(entity.User)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -162,15 +161,14 @@ type UserdataManager_GetUserData_Call struct {
 
 // GetUserData is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *UserdataManager_Expecter) GetUserData(ctx interface{}, clientID interface{}, userID interface{}) *UserdataManager_GetUserData_Call {
-	return &UserdataManager_GetUserData_Call{Call: _e.mock.On("GetUserData", ctx, clientID, userID)}
+func (_e *UserdataManager_Expecter) GetUserData(ctx interface{}, userID interface{}) *UserdataManager_GetUserData_Call {
+	return &UserdataManager_GetUserData_Call{Call: _e.mock.On("GetUserData", ctx, userID)}
 }
 
-func (_c *UserdataManager_GetUserData_Call) Run(run func(ctx context.Context, clientID string, userID string)) *UserdataManager_GetUserData_Call {
+func (_c *UserdataManager_GetUserData_Call) Run(run func(ctx context.Context, userID string)) *UserdataManager_GetUserData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -180,14 +178,14 @@ func (_c *UserdataManager_GetUserData_Call) Return(_a0 entity.User, _a1 error) *
 	return _c
 }
 
-func (_c *UserdataManager_GetUserData_Call) RunAndReturn(run func(context.Context, string, string) (entity.User, error)) *UserdataManager_GetUserData_Call {
+func (_c *UserdataManager_GetUserData_Call) RunAndReturn(run func(context.Context, string) (entity.User, error)) *UserdataManager_GetUserData_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserStatusByEmail provides a mock function with given fields: ctx, clientID, email
-func (_m *UserdataManager) GetUserStatusByEmail(ctx context.Context, clientID string, email string) (string, error) {
-	ret := _m.Called(ctx, clientID, email)
+// GetUserStatusByEmail provides a mock function with given fields: ctx, email
+func (_m *UserdataManager) GetUserStatusByEmail(ctx context.Context, email string) (string, error) {
+	ret := _m.Called(ctx, email)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserStatusByEmail")
@@ -195,17 +193,17 @@ func (_m *UserdataManager) GetUserStatusByEmail(ctx context.Context, clientID st
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
-		return rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, email)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, email)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, email)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, email)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -220,15 +218,14 @@ type UserdataManager_GetUserStatusByEmail_Call struct {
 
 // GetUserStatusByEmail is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - email string
-func (_e *UserdataManager_Expecter) GetUserStatusByEmail(ctx interface{}, clientID interface{}, email interface{}) *UserdataManager_GetUserStatusByEmail_Call {
-	return &UserdataManager_GetUserStatusByEmail_Call{Call: _e.mock.On("GetUserStatusByEmail", ctx, clientID, email)}
+func (_e *UserdataManager_Expecter) GetUserStatusByEmail(ctx interface{}, email interface{}) *UserdataManager_GetUserStatusByEmail_Call {
+	return &UserdataManager_GetUserStatusByEmail_Call{Call: _e.mock.On("GetUserStatusByEmail", ctx, email)}
 }
 
-func (_c *UserdataManager_GetUserStatusByEmail_Call) Run(run func(ctx context.Context, clientID string, email string)) *UserdataManager_GetUserStatusByEmail_Call {
+func (_c *UserdataManager_GetUserStatusByEmail_Call) Run(run func(ctx context.Context, email string)) *UserdataManager_GetUserStatusByEmail_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -238,14 +235,14 @@ func (_c *UserdataManager_GetUserStatusByEmail_Call) Return(_a0 string, _a1 erro
 	return _c
 }
 
-func (_c *UserdataManager_GetUserStatusByEmail_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *UserdataManager_GetUserStatusByEmail_Call {
+func (_c *UserdataManager_GetUserStatusByEmail_Call) RunAndReturn(run func(context.Context, string) (string, error)) *UserdataManager_GetUserStatusByEmail_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetUserStatusByID provides a mock function with given fields: ctx, clientID, userID
-func (_m *UserdataManager) GetUserStatusByID(ctx context.Context, clientID string, userID string) (string, error) {
-	ret := _m.Called(ctx, clientID, userID)
+// GetUserStatusByID provides a mock function with given fields: ctx, userID
+func (_m *UserdataManager) GetUserStatusByID(ctx context.Context, userID string) (string, error) {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetUserStatusByID")
@@ -253,17 +250,17 @@ func (_m *UserdataManager) GetUserStatusByID(ctx context.Context, clientID strin
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (string, error)); ok {
-		return rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) string); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -278,15 +275,14 @@ type UserdataManager_GetUserStatusByID_Call struct {
 
 // GetUserStatusByID is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *UserdataManager_Expecter) GetUserStatusByID(ctx interface{}, clientID interface{}, userID interface{}) *UserdataManager_GetUserStatusByID_Call {
-	return &UserdataManager_GetUserStatusByID_Call{Call: _e.mock.On("GetUserStatusByID", ctx, clientID, userID)}
+func (_e *UserdataManager_Expecter) GetUserStatusByID(ctx interface{}, userID interface{}) *UserdataManager_GetUserStatusByID_Call {
+	return &UserdataManager_GetUserStatusByID_Call{Call: _e.mock.On("GetUserStatusByID", ctx, userID)}
 }
 
-func (_c *UserdataManager_GetUserStatusByID_Call) Run(run func(ctx context.Context, clientID string, userID string)) *UserdataManager_GetUserStatusByID_Call {
+func (_c *UserdataManager_GetUserStatusByID_Call) Run(run func(ctx context.Context, userID string)) *UserdataManager_GetUserStatusByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -296,7 +292,7 @@ func (_c *UserdataManager_GetUserStatusByID_Call) Return(_a0 string, _a1 error) 
 	return _c
 }
 
-func (_c *UserdataManager_GetUserStatusByID_Call) RunAndReturn(run func(context.Context, string, string) (string, error)) *UserdataManager_GetUserStatusByID_Call {
+func (_c *UserdataManager_GetUserStatusByID_Call) RunAndReturn(run func(context.Context, string) (string, error)) *UserdataManager_GetUserStatusByID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/usecase/user/mocks/mock_VerificationManager.go
+++ b/internal/domain/usecase/user/mocks/mock_VerificationManager.go
@@ -21,17 +21,17 @@ func (_m *VerificationManager) EXPECT() *VerificationManager_Expecter {
 	return &VerificationManager_Expecter{mock: &_m.Mock}
 }
 
-// DeleteAllTokens provides a mock function with given fields: ctx, clientID, userID
-func (_m *VerificationManager) DeleteAllTokens(ctx context.Context, clientID string, userID string) error {
-	ret := _m.Called(ctx, clientID, userID)
+// DeleteAllTokens provides a mock function with given fields: ctx, userID
+func (_m *VerificationManager) DeleteAllTokens(ctx context.Context, userID string) error {
+	ret := _m.Called(ctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteAllTokens")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = rf(ctx, clientID, userID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -46,15 +46,14 @@ type VerificationManager_DeleteAllTokens_Call struct {
 
 // DeleteAllTokens is a helper method to define mock.On call
 //   - ctx context.Context
-//   - clientID string
 //   - userID string
-func (_e *VerificationManager_Expecter) DeleteAllTokens(ctx interface{}, clientID interface{}, userID interface{}) *VerificationManager_DeleteAllTokens_Call {
-	return &VerificationManager_DeleteAllTokens_Call{Call: _e.mock.On("DeleteAllTokens", ctx, clientID, userID)}
+func (_e *VerificationManager_Expecter) DeleteAllTokens(ctx interface{}, userID interface{}) *VerificationManager_DeleteAllTokens_Call {
+	return &VerificationManager_DeleteAllTokens_Call{Call: _e.mock.On("DeleteAllTokens", ctx, userID)}
 }
 
-func (_c *VerificationManager_DeleteAllTokens_Call) Run(run func(ctx context.Context, clientID string, userID string)) *VerificationManager_DeleteAllTokens_Call {
+func (_c *VerificationManager_DeleteAllTokens_Call) Run(run func(ctx context.Context, userID string)) *VerificationManager_DeleteAllTokens_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -64,7 +63,7 @@ func (_c *VerificationManager_DeleteAllTokens_Call) Return(_a0 error) *Verificat
 	return _c
 }
 
-func (_c *VerificationManager_DeleteAllTokens_Call) RunAndReturn(run func(context.Context, string, string) error) *VerificationManager_DeleteAllTokens_Call {
+func (_c *VerificationManager_DeleteAllTokens_Call) RunAndReturn(run func(context.Context, string) error) *VerificationManager_DeleteAllTokens_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/domain/usecase/user/user_usecase_test.go
+++ b/internal/domain/usecase/user/user_usecase_test.go
@@ -23,7 +23,6 @@ func TestUserUsecase_GetUser(t *testing.T) {
 	expectedUser := entity.User{
 		ID:        userID,
 		Email:     "test@example.com",
-		ClientID:  clientID,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
@@ -41,7 +40,7 @@ func TestUserUsecase_GetUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserByID(ctx, userID).
 					Once().
 					Return(expectedUser, nil)
 			},
@@ -65,7 +64,7 @@ func TestUserUsecase_GetUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserByID(ctx, userID).
 					Once().
 					Return(entity.User{}, domain.ErrUserNotFound)
 			},
@@ -79,7 +78,7 @@ func TestUserUsecase_GetUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserByID(ctx, userID).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user manager error"))
 			},
@@ -119,7 +118,6 @@ func TestUserUsecase_GetUserByID(t *testing.T) {
 	expectedUser := entity.User{
 		ID:        userID,
 		Email:     "test@example.com",
-		ClientID:  clientID,
 		CreatedAt: time.Now(),
 		UpdatedAt: time.Now(),
 	}
@@ -133,7 +131,7 @@ func TestUserUsecase_GetUserByID(t *testing.T) {
 		{
 			name: "Success",
 			mockBehavior: func(userMgr *mocks.UserdataManager) {
-				userMgr.EXPECT().GetUserByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserByID(ctx, userID).
 					Once().
 					Return(expectedUser, nil)
 			},
@@ -143,7 +141,7 @@ func TestUserUsecase_GetUserByID(t *testing.T) {
 		{
 			name: "User not found",
 			mockBehavior: func(userMgr *mocks.UserdataManager) {
-				userMgr.EXPECT().GetUserByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserByID(ctx, userID).
 					Once().
 					Return(entity.User{}, domain.ErrUserNotFound)
 			},
@@ -153,7 +151,7 @@ func TestUserUsecase_GetUserByID(t *testing.T) {
 		{
 			name: "Failed to get user",
 			mockBehavior: func(userMgr *mocks.UserdataManager) {
-				userMgr.EXPECT().GetUserByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserByID(ctx, userID).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user manager error"))
 			},
@@ -199,7 +197,6 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 		ID:           userID,
 		Email:        currentEmail,
 		PasswordHash: currentPasswordHash,
-		ClientID:     clientID,
 	}
 
 	tests := []struct {
@@ -226,11 +223,11 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, newEmail).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, newEmail).
 					Once().
 					Return(entity.UserStatusNotFound.String(), nil)
 
@@ -255,7 +252,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
@@ -309,7 +306,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{}, domain.ErrUserNotFound)
 			},
@@ -329,7 +326,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(entity.User{}, fmt.Errorf("user manager error"))
 			},
@@ -349,11 +346,11 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, newEmail).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, newEmail).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 			},
@@ -373,7 +370,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 			},
@@ -393,11 +390,11 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
-				userMgr.EXPECT().GetUserStatusByEmail(ctx, clientID, newEmail).
+				userMgr.EXPECT().GetUserStatusByEmail(ctx, newEmail).
 					Once().
 					Return("", fmt.Errorf("user manager error"))
 			},
@@ -418,7 +415,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
@@ -445,7 +442,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
@@ -472,7 +469,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
@@ -503,7 +500,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
@@ -534,7 +531,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
@@ -569,7 +566,7 @@ func TestUserUsecase_UpdateUser(t *testing.T) {
 					Once().
 					Return(userID, nil)
 
-				userMgr.EXPECT().GetUserData(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserData(ctx, userID).
 					Once().
 					Return(existingUser, nil)
 
@@ -653,7 +650,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -669,7 +666,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 					Once().
 					Return(nil)
 
-				verificationMgr.EXPECT().DeleteAllTokens(ctx, clientID, userID).
+				verificationMgr.EXPECT().DeleteAllTokens(ctx, userID).
 					Once().
 					Return(nil)
 			},
@@ -708,7 +705,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusSoftDeleted.String(), nil)
 			},
@@ -732,7 +729,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return("some-unknown-user-status", nil)
 			},
@@ -756,7 +753,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return("", fmt.Errorf("user manager error"))
 			},
@@ -780,7 +777,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -808,7 +805,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -840,7 +837,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -876,7 +873,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -892,7 +889,7 @@ func TestUserUsecase_DeleteUser(t *testing.T) {
 					Once().
 					Return(nil)
 
-				verificationMgr.EXPECT().DeleteAllTokens(ctx, clientID, userID).
+				verificationMgr.EXPECT().DeleteAllTokens(ctx, userID).
 					Once().
 					Return(fmt.Errorf("verification manager error"))
 			},
@@ -973,7 +970,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -989,7 +986,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 					Once().
 					Return(nil)
 
-				verificationMgr.EXPECT().DeleteAllTokens(ctx, clientID, userID).
+				verificationMgr.EXPECT().DeleteAllTokens(ctx, userID).
 					Once().
 					Return(nil)
 			},
@@ -1008,7 +1005,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusSoftDeleted.String(), nil)
 			},
@@ -1027,7 +1024,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return("some-unknown-user-status", nil)
 			},
@@ -1046,7 +1043,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return("", fmt.Errorf("user manager error"))
 			},
@@ -1065,7 +1062,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -1088,7 +1085,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -1115,7 +1112,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -1146,7 +1143,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 						return fn(ctx)
 					})
 
-				userMgr.EXPECT().GetUserStatusByID(ctx, clientID, userID).
+				userMgr.EXPECT().GetUserStatusByID(ctx, userID).
 					Once().
 					Return(entity.UserStatusActive.String(), nil)
 
@@ -1162,7 +1159,7 @@ func TestUserUsecase_DeleteUserByID(t *testing.T) {
 					Once().
 					Return(nil)
 
-				verificationMgr.EXPECT().DeleteAllTokens(ctx, clientID, userID).
+				verificationMgr.EXPECT().DeleteAllTokens(ctx, userID).
 					Once().
 					Return(fmt.Errorf("verification manager error"))
 			},

--- a/internal/infrastructure/storage/auth/mongo/auth.go
+++ b/internal/infrastructure/storage/auth/mongo/auth.go
@@ -42,8 +42,7 @@ func (s *AuthStorage) ReplaceSoftDeletedUser(ctx context.Context, user entity.Us
 	defer cancel()
 
 	filter := bson.M{
-		common.FieldEmail:    user.Email,
-		common.FieldClientID: user.ClientID,
+		common.FieldEmail: user.Email,
 		common.FieldDeletedAt: bson.M{
 			"$ne": nil,
 		},
@@ -83,15 +82,14 @@ func (s *AuthStorage) RegisterUser(ctx context.Context, user entity.User) error 
 	return nil
 }
 
-func (s *AuthStorage) MarkEmailVerified(ctx context.Context, userID, clientID string) error {
+func (s *AuthStorage) MarkEmailVerified(ctx context.Context, userID string) error {
 	const method = "storage.auth.mongo.MarkEmailVerified"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
 	filter := bson.M{
-		common.FieldID:       userID,
-		common.FieldClientID: clientID,
+		common.FieldID: userID,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},

--- a/internal/infrastructure/storage/auth/postgres/query/auth.sql
+++ b/internal/infrastructure/storage/auth/postgres/query/auth.sql
@@ -1,23 +1,21 @@
 -- name: RegisterUser :exec
-INSERT INTO users (id, email, password_hash, client_id, verified, created_at,updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7);
+INSERT INTO users (id, email, password_hash, verified, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6);
 
 -- name: ReplaceSoftDeletedUser :exec
 UPDATE users
 SET
     id = $1,
     password_hash = $2,
-    client_id = $3,
-    verified = $4,
-    created_at = $5,
-    updated_at = $6,
+    verified = $3,
+    created_at = $4,
+    updated_at = $5,
     deleted_at = NULL
-WHERE email = $7
+WHERE email = $6
   AND deleted_at IS NOT NULL;
 
 -- name: MarkEmailVerified :exec
 UPDATE users
 SET verified = TRUE
 WHERE id = $1
-  AND client_id = $2
   AND deleted_at IS NULL;

--- a/internal/infrastructure/storage/auth/postgres/sqlc/auth.sql.go
+++ b/internal/infrastructure/storage/auth/postgres/sqlc/auth.sql.go
@@ -16,30 +16,23 @@ const markEmailVerified = `-- name: MarkEmailVerified :exec
 UPDATE users
 SET verified = TRUE
 WHERE id = $1
-  AND client_id = $2
   AND deleted_at IS NULL
 `
 
-type MarkEmailVerifiedParams struct {
-	ID       string `db:"id"`
-	ClientID string `db:"client_id"`
-}
-
-func (q *Queries) MarkEmailVerified(ctx context.Context, arg MarkEmailVerifiedParams) error {
-	_, err := q.db.Exec(ctx, markEmailVerified, arg.ID, arg.ClientID)
+func (q *Queries) MarkEmailVerified(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, markEmailVerified, id)
 	return err
 }
 
 const registerUser = `-- name: RegisterUser :exec
-INSERT INTO users (id, email, password_hash, client_id, verified, created_at,updated_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO users (id, email, password_hash, verified, created_at,updated_at)
+VALUES ($1, $2, $3, $4, $5, $6)
 `
 
 type RegisterUserParams struct {
 	ID           string      `db:"id"`
 	Email        string      `db:"email"`
 	PasswordHash string      `db:"password_hash"`
-	ClientID     string      `db:"client_id"`
 	Verified     pgtype.Bool `db:"verified"`
 	CreatedAt    time.Time   `db:"created_at"`
 	UpdatedAt    time.Time   `db:"updated_at"`
@@ -50,7 +43,6 @@ func (q *Queries) RegisterUser(ctx context.Context, arg RegisterUserParams) erro
 		arg.ID,
 		arg.Email,
 		arg.PasswordHash,
-		arg.ClientID,
 		arg.Verified,
 		arg.CreatedAt,
 		arg.UpdatedAt,
@@ -63,19 +55,17 @@ UPDATE users
 SET
     id = $1,
     password_hash = $2,
-    client_id = $3,
-    verified = $4,
-    created_at = $5,
-    updated_at = $6,
+    verified = $3,
+    created_at = $4,
+    updated_at = $5,
     deleted_at = NULL
-WHERE email = $7
+WHERE email = $6
   AND deleted_at IS NOT NULL
 `
 
 type ReplaceSoftDeletedUserParams struct {
 	ID           string      `db:"id"`
 	PasswordHash string      `db:"password_hash"`
-	ClientID     string      `db:"client_id"`
 	Verified     pgtype.Bool `db:"verified"`
 	CreatedAt    time.Time   `db:"created_at"`
 	UpdatedAt    time.Time   `db:"updated_at"`
@@ -86,7 +76,6 @@ func (q *Queries) ReplaceSoftDeletedUser(ctx context.Context, arg ReplaceSoftDel
 	_, err := q.db.Exec(ctx, replaceSoftDeletedUser,
 		arg.ID,
 		arg.PasswordHash,
-		arg.ClientID,
 		arg.Verified,
 		arg.CreatedAt,
 		arg.UpdatedAt,

--- a/internal/infrastructure/storage/auth/postgres/sqlc/models.go
+++ b/internal/infrastructure/storage/auth/postgres/sqlc/models.go
@@ -28,7 +28,6 @@ type ClientStatus struct {
 type Token struct {
 	Token       string    `db:"token"`
 	UserID      string    `db:"user_id"`
-	ClientID    string    `db:"client_id"`
 	Endpoint    string    `db:"endpoint"`
 	Recipient   string    `db:"recipient"`
 	TokenTypeID int32     `db:"token_type_id"`
@@ -45,7 +44,6 @@ type User struct {
 	ID           string             `db:"id"`
 	Email        string             `db:"email"`
 	PasswordHash string             `db:"password_hash"`
-	ClientID     string             `db:"client_id"`
 	Verified     pgtype.Bool        `db:"verified"`
 	CreatedAt    time.Time          `db:"created_at"`
 	UpdatedAt    time.Time          `db:"updated_at"`
@@ -55,7 +53,6 @@ type User struct {
 type UserDevice struct {
 	ID            string             `db:"id"`
 	UserID        string             `db:"user_id"`
-	ClientID      string             `db:"client_id"`
 	UserAgent     string             `db:"user_agent"`
 	Ip            string             `db:"ip"`
 	Detached      bool               `db:"detached"`

--- a/internal/infrastructure/storage/auth/postgres/sqlc/querier.go
+++ b/internal/infrastructure/storage/auth/postgres/sqlc/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	MarkEmailVerified(ctx context.Context, arg MarkEmailVerifiedParams) error
+	MarkEmailVerified(ctx context.Context, id string) error
 	RegisterUser(ctx context.Context, arg RegisterUserParams) error
 	ReplaceSoftDeletedUser(ctx context.Context, arg ReplaceSoftDeletedUserParams) error
 }

--- a/internal/infrastructure/storage/client/postgres/sqlc/models.go
+++ b/internal/infrastructure/storage/client/postgres/sqlc/models.go
@@ -28,7 +28,6 @@ type ClientStatus struct {
 type Token struct {
 	Token       string    `db:"token"`
 	UserID      string    `db:"user_id"`
-	ClientID    string    `db:"client_id"`
 	Endpoint    string    `db:"endpoint"`
 	Recipient   string    `db:"recipient"`
 	TokenTypeID int32     `db:"token_type_id"`
@@ -45,7 +44,6 @@ type User struct {
 	ID           string             `db:"id"`
 	Email        string             `db:"email"`
 	PasswordHash string             `db:"password_hash"`
-	ClientID     string             `db:"client_id"`
 	Verified     pgtype.Bool        `db:"verified"`
 	CreatedAt    time.Time          `db:"created_at"`
 	UpdatedAt    time.Time          `db:"updated_at"`
@@ -55,7 +53,6 @@ type User struct {
 type UserDevice struct {
 	ID            string             `db:"id"`
 	UserID        string             `db:"user_id"`
-	ClientID      string             `db:"client_id"`
 	UserAgent     string             `db:"user_agent"`
 	Ip            string             `db:"ip"`
 	Detached      bool               `db:"detached"`

--- a/internal/infrastructure/storage/device/mongo/device.go
+++ b/internal/infrastructure/storage/device/mongo/device.go
@@ -53,7 +53,7 @@ func (s *DeviceStorage) RegisterDevice(ctx context.Context, device entity.UserDe
 	return nil
 }
 
-func (s *DeviceStorage) GetUserDeviceID(ctx context.Context, userID, clientID, userAgent string) (string, error) {
+func (s *DeviceStorage) GetUserDeviceID(ctx context.Context, userID, userAgent string) (string, error) {
 	const method = "storage.session.mongo.GetUserDeviceID"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
@@ -61,7 +61,6 @@ func (s *DeviceStorage) GetUserDeviceID(ctx context.Context, userID, clientID, u
 
 	filter := bson.M{
 		fieldUserID:    userID,
-		fieldAppID:     clientID,
 		fieldUserAgent: userAgent,
 	}
 
@@ -112,7 +111,7 @@ func (s *DeviceStorage) UpdateLastVisitedAt(ctx context.Context, session entity.
 	return nil
 }
 
-func (s *DeviceStorage) DeleteAllUserDevices(ctx context.Context, userID, clientID string) error {
+func (s *DeviceStorage) DeleteAllUserDevices(ctx context.Context, userID string) error {
 	const method = "storage.session.mongo.DeleteAllUserDevices"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
@@ -120,7 +119,6 @@ func (s *DeviceStorage) DeleteAllUserDevices(ctx context.Context, userID, client
 
 	filter := bson.M{
 		fieldUserID: userID,
-		fieldAppID:  clientID,
 	}
 
 	result, err := s.devicesColl.DeleteMany(ctx, filter)

--- a/internal/infrastructure/storage/device/mongo/models.go
+++ b/internal/infrastructure/storage/device/mongo/models.go
@@ -9,7 +9,6 @@ import (
 const (
 	fieldID            = "_id"
 	fieldUserID        = "user_id"
-	fieldAppID         = "client_id"
 	fieldUserAgent     = "user_agent"
 	fieldLastVisitedAt = "last_visited_at"
 )
@@ -17,7 +16,6 @@ const (
 type deviceDocument struct {
 	ID            string    `bson:"_id"`
 	UserID        string    `bson:"user_id"`
-	ClientID      string    `bson:"client_id"`
 	UserAgent     string    `bson:"user_agent"`
 	IP            string    `bson:"ip"`
 	Detached      bool      `bson:"detached"`
@@ -29,7 +27,6 @@ func toDeviceDoc(device entity.UserDevice) deviceDocument {
 	return deviceDocument{
 		ID:            device.ID,
 		UserID:        device.UserID,
-		ClientID:      device.ClientID,
 		UserAgent:     device.UserAgent,
 		IP:            device.IP,
 		Detached:      device.Detached,

--- a/internal/infrastructure/storage/device/postgres/query/query.sql
+++ b/internal/infrastructure/storage/device/postgres/query/query.sql
@@ -1,22 +1,20 @@
 -- name: RegisterDevice :exec
-INSERT INTO user_devices (id, user_id, client_id, user_agent, ip, detached, last_visited_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7);
+INSERT INTO user_devices (id, user_id, user_agent, ip, detached, last_visited_at)
+VALUES ($1, $2, $3, $4, $5, $6);
 
 -- name: UpdateLastVisitedAt :exec
 UPDATE user_devices
 SET last_visited_at = $1
-WHERE id = $2
-  AND client_id = $3;
+WHERE id = $2;
 
 -- name: GetUserDeviceID :one
 SELECT id
 FROM user_devices
 WHERE user_id = $1
   AND user_agent = $2
-  AND client_id = $3
   AND detached = FALSE;
 
 -- name: DeleteAllUserDevices :exec
 DELETE FROM user_devices
 WHERE user_id = $1
-  AND client_id = $2;
+  AND detached = FALSE;

--- a/internal/infrastructure/storage/device/postgres/sqlc/models.go
+++ b/internal/infrastructure/storage/device/postgres/sqlc/models.go
@@ -28,7 +28,6 @@ type ClientStatus struct {
 type Token struct {
 	Token       string    `db:"token"`
 	UserID      string    `db:"user_id"`
-	ClientID    string    `db:"client_id"`
 	Endpoint    string    `db:"endpoint"`
 	Recipient   string    `db:"recipient"`
 	TokenTypeID int32     `db:"token_type_id"`
@@ -45,7 +44,6 @@ type User struct {
 	ID           string             `db:"id"`
 	Email        string             `db:"email"`
 	PasswordHash string             `db:"password_hash"`
-	ClientID     string             `db:"client_id"`
 	Verified     pgtype.Bool        `db:"verified"`
 	CreatedAt    time.Time          `db:"created_at"`
 	UpdatedAt    time.Time          `db:"updated_at"`
@@ -55,7 +53,6 @@ type User struct {
 type UserDevice struct {
 	ID            string             `db:"id"`
 	UserID        string             `db:"user_id"`
-	ClientID      string             `db:"client_id"`
 	UserAgent     string             `db:"user_agent"`
 	Ip            string             `db:"ip"`
 	Detached      bool               `db:"detached"`

--- a/internal/infrastructure/storage/device/postgres/sqlc/querier.go
+++ b/internal/infrastructure/storage/device/postgres/sqlc/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	DeleteAllUserDevices(ctx context.Context, arg DeleteAllUserDevicesParams) error
+	DeleteAllUserDevices(ctx context.Context, userID string) error
 	GetUserDeviceID(ctx context.Context, arg GetUserDeviceIDParams) (string, error)
 	RegisterDevice(ctx context.Context, arg RegisterDeviceParams) error
 	UpdateLastVisitedAt(ctx context.Context, arg UpdateLastVisitedAtParams) error

--- a/internal/infrastructure/storage/mongo/common/user_models.go
+++ b/internal/infrastructure/storage/mongo/common/user_models.go
@@ -23,7 +23,6 @@ type UserDocument struct {
 	ID           string     `bson:"_id"`
 	Email        string     `bson:"email"`
 	PasswordHash string     `bson:"password_hash"`
-	ClientID     string     `bson:"client_id"`
 	Verified     bool       `bson:"verified"`
 	CreatedAt    time.Time  `bson:"created_at"`
 	UpdatedAt    time.Time  `bson:"updated_at"`
@@ -40,7 +39,6 @@ func ToUserDoc(user entity.User) UserDocument {
 		ID:           user.ID,
 		Email:        user.Email,
 		PasswordHash: user.PasswordHash,
-		ClientID:     user.ClientID,
 		Verified:     user.Verified,
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,
@@ -53,7 +51,6 @@ func ToUserEntity(doc UserDocument) entity.User {
 		ID:           doc.ID,
 		Email:        doc.Email,
 		PasswordHash: doc.PasswordHash,
-		ClientID:     doc.ClientID,
 		Verified:     doc.Verified,
 		CreatedAt:    doc.CreatedAt,
 		UpdatedAt:    doc.UpdatedAt,

--- a/internal/infrastructure/storage/session/redis/models.go
+++ b/internal/infrastructure/storage/session/redis/models.go
@@ -13,7 +13,6 @@ const (
 	revokedTokenKeyPrefix = "revoked_token"
 	refreshIndexPrefix    = "refresh_index"
 	userIDKeyPrefix       = "user_id"
-	clientIDKeyPrefix     = "client_id"
 	deviceIDKeyPrefix     = "device_id"
 	expiresAtKeyPrefix    = "expires_at"
 	refreshTokenKeyPrefix = "refresh_token"
@@ -22,7 +21,6 @@ const (
 func toRedisSessionData(session entity.Session) map[string]any {
 	return map[string]any{
 		userIDKeyPrefix:       session.UserID,
-		clientIDKeyPrefix:     session.ClientID,
 		deviceIDKeyPrefix:     session.DeviceID,
 		refreshTokenKeyPrefix: session.RefreshToken,
 		expiresAtKeyPrefix:    session.ExpiresAt.Unix(),
@@ -33,7 +31,6 @@ func toSessionEntity(data map[string]string) entity.Session {
 	expiresAt, _ := strconv.ParseInt(data[expiresAtKeyPrefix], 10, 64)
 	return entity.Session{
 		UserID:       data[userIDKeyPrefix],
-		ClientID:     data[clientIDKeyPrefix],
 		DeviceID:     data[deviceIDKeyPrefix],
 		RefreshToken: data[refreshTokenKeyPrefix],
 		ExpiresAt:    time.Unix(expiresAt, 0),

--- a/internal/infrastructure/storage/session/redis/session.go
+++ b/internal/infrastructure/storage/session/redis/session.go
@@ -38,7 +38,7 @@ func NewSessionStorage(redisConn *storage.RedisConnection) (*SessionStorage, err
 func (s *SessionStorage) CreateSession(ctx context.Context, session entity.Session) error {
 	const method = "storage.redis.CreateSession"
 
-	sessionKey := s.sessionKey(session.UserID, session.ClientID, session.DeviceID)
+	sessionKey := s.sessionKey(session.UserID, session.DeviceID)
 	data := toRedisSessionData(session)
 
 	if err := s.client.HSet(ctx, sessionKey, data).Err(); err != nil {
@@ -106,7 +106,7 @@ func (s *SessionStorage) DeleteRefreshToken(ctx context.Context, refreshToken st
 func (s *SessionStorage) DeleteSession(ctx context.Context, session entity.Session) error {
 	const method = "storage.redis.DeleteSession"
 
-	sessionKey := s.sessionKey(session.UserID, session.ClientID, session.DeviceID)
+	sessionKey := s.sessionKey(session.UserID, session.DeviceID)
 
 	data, err := s.client.HGetAll(ctx, sessionKey).Result()
 	if err != nil {
@@ -125,10 +125,10 @@ func (s *SessionStorage) DeleteSession(ctx context.Context, session entity.Sessi
 	return nil
 }
 
-func (s *SessionStorage) DeleteAllSessions(ctx context.Context, userID, clientID string) error {
+func (s *SessionStorage) DeleteAllSessions(ctx context.Context, userID string) error {
 	const method = "storage.redis.DeleteAllSessions"
 
-	pattern := fmt.Sprintf("%s:%s:%s:*", sessionKeyPrefix, userID, clientID)
+	pattern := fmt.Sprintf("%s:%s:*", sessionKeyPrefix, userID)
 	iter := s.client.Scan(ctx, 0, pattern, 0).Iterator()
 
 	var keysToDelete []string
@@ -192,8 +192,8 @@ func (s *SessionStorage) IsAccessTokenRevoked(ctx context.Context, token string)
 	return true, nil
 }
 
-func (s *SessionStorage) sessionKey(userID, clientID, deviceID string) string {
-	return fmt.Sprintf("%s:%s:%s:%s", sessionKeyPrefix, userID, clientID, deviceID)
+func (s *SessionStorage) sessionKey(userID, deviceID string) string {
+	return fmt.Sprintf("%s:%s:%s", sessionKeyPrefix, userID, deviceID)
 }
 
 func (s *SessionStorage) refreshIndexKey(refreshToken string) string {

--- a/internal/infrastructure/storage/user/mongo/user.go
+++ b/internal/infrastructure/storage/user/mongo/user.go
@@ -39,15 +39,14 @@ func NewUserStorage(db *mongo.Database, timeout time.Duration) (*UserStorage, er
 	}, nil
 }
 
-func (s *UserStorage) GetUserByID(ctx context.Context, clientID, userID string) (entity.User, error) {
+func (s *UserStorage) GetUserByID(ctx context.Context, userID string) (entity.User, error) {
 	const method = "storage.user.mongo.GetUserByID"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
 	filter := bson.M{
-		common.FieldClientID: clientID,
-		common.FieldID:       userID,
+		common.FieldID: userID,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},
@@ -70,15 +69,14 @@ func (s *UserStorage) GetUserByID(ctx context.Context, clientID, userID string) 
 	return common.ToUserEntity(doc), nil
 }
 
-func (s *UserStorage) GetUserByEmail(ctx context.Context, clientID, email string) (entity.User, error) {
+func (s *UserStorage) GetUserByEmail(ctx context.Context, email string) (entity.User, error) {
 	const method = "storage.user.mongo.GetUserByEmail"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
 	filter := bson.M{
-		common.FieldClientID: clientID,
-		common.FieldEmail:    email,
+		common.FieldEmail: email,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},
@@ -101,15 +99,14 @@ func (s *UserStorage) GetUserByEmail(ctx context.Context, clientID, email string
 	return common.ToUserEntity(doc), nil
 }
 
-func (s *UserStorage) GetUserData(ctx context.Context, clientID, userID string) (entity.User, error) {
+func (s *UserStorage) GetUserData(ctx context.Context, userID string) (entity.User, error) {
 	const method = "storage.user.mongo.GetUserData"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
 	filter := bson.M{
-		common.FieldClientID: clientID,
-		common.FieldID:       userID,
+		common.FieldID: userID,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},
@@ -119,7 +116,6 @@ func (s *UserStorage) GetUserData(ctx context.Context, clientID, userID string) 
 		common.FieldID:           1,
 		common.FieldEmail:        1,
 		common.FieldPasswordHash: 1,
-		common.FieldClientID:     1,
 		common.FieldUpdatedAt:    1,
 	})
 
@@ -147,8 +143,7 @@ func (s *UserStorage) UpdateUser(ctx context.Context, user entity.User) error {
 	defer cancel()
 
 	filter := bson.M{
-		common.FieldClientID: user.ClientID,
-		common.FieldID:       user.ID,
+		common.FieldID: user.ID,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},
@@ -185,7 +180,7 @@ func buildUpdateFields(user entity.User) bson.M {
 	return update
 }
 
-func (s *UserStorage) GetUserStatusByEmail(ctx context.Context, clientID, email string) (string, error) {
+func (s *UserStorage) GetUserStatusByEmail(ctx context.Context, email string) (string, error) {
 	const method = "storage.user.mongo.GetUserStatusByEmail"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
@@ -193,8 +188,7 @@ func (s *UserStorage) GetUserStatusByEmail(ctx context.Context, clientID, email 
 
 	// Check active user
 	filter := bson.M{
-		common.FieldClientID: clientID,
-		common.FieldEmail:    email,
+		common.FieldEmail: email,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},
@@ -210,8 +204,7 @@ func (s *UserStorage) GetUserStatusByEmail(ctx context.Context, clientID, email 
 
 	// Check soft deleted user
 	filter = bson.M{
-		common.FieldClientID: clientID,
-		common.FieldEmail:    email,
+		common.FieldEmail: email,
 		common.FieldDeletedAt: bson.M{
 			"$ne": nil,
 		},
@@ -228,7 +221,7 @@ func (s *UserStorage) GetUserStatusByEmail(ctx context.Context, clientID, email 
 	return entity.UserStatusNotFound.String(), nil
 }
 
-func (s *UserStorage) GetUserStatusByID(ctx context.Context, clientID, userID string) (string, error) {
+func (s *UserStorage) GetUserStatusByID(ctx context.Context, userID string) (string, error) {
 	const method = "storage.user.mongo.GetUserStatusByID"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
@@ -236,8 +229,7 @@ func (s *UserStorage) GetUserStatusByID(ctx context.Context, clientID, userID st
 
 	// Check active user
 	filter := bson.M{
-		common.FieldClientID: clientID,
-		common.FieldID:       userID,
+		common.FieldID: userID,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},
@@ -253,8 +245,7 @@ func (s *UserStorage) GetUserStatusByID(ctx context.Context, clientID, userID st
 
 	// Check soft deleted user
 	filter = bson.M{
-		common.FieldClientID: clientID,
-		common.FieldID:       userID,
+		common.FieldID: userID,
 		common.FieldDeletedAt: bson.M{
 			"$ne": nil,
 		},
@@ -278,8 +269,7 @@ func (s *UserStorage) DeleteUser(ctx context.Context, user entity.User) error {
 	defer cancel()
 
 	filter := bson.M{
-		common.FieldID:       user.ID,
-		common.FieldClientID: user.ClientID,
+		common.FieldID: user.ID,
 		common.FieldDeletedAt: bson.M{
 			"$exists": false,
 		},

--- a/internal/infrastructure/storage/user/postgres/query/user.sql
+++ b/internal/infrastructure/storage/user/postgres/query/user.sql
@@ -1,29 +1,25 @@
 -- name: GetUserByID :one
-SELECT id, email, client_id, verified, updated_at
+SELECT id, email, verified, updated_at
 FROM users
 WHERE id = $1
-  AND client_id = $2
   AND deleted_at IS NULL;
 
 -- name: GetUserByEmail :one
-SELECT id, email, client_id, updated_at
+SELECT id, email, updated_at
 FROM users
 WHERE email = $1
-  AND client_id = $2
   AND deleted_at IS NULL;
 
 -- name: GetUserData :one
-SELECT id, email, password_hash, client_id, updated_at
+SELECT id, email, password_hash, updated_at
 FROM users
 WHERE id = $1
-  AND client_id = $2
   AND deleted_at IS NULL;
 
 -- name: DeleteUser :exec
 UPDATE users
 SET deleted_at = $1
 WHERE id = $2
-  AND client_id = $3
   AND deleted_at IS NULL;
 
 -- name: GetUserStatusByEmail :one
@@ -32,14 +28,12 @@ SELECT CASE
                SELECT 1
                FROM users
                WHERE users.email = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NULL
            ) THEN 'active'
            WHEN EXISTS(
                SELECT 1
                FROM users
                WHERE users.email = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NOT NULL
            ) THEN 'soft_deleted'
            ELSE 'not_found' END AS status;
@@ -50,14 +44,12 @@ SELECT CASE
                SELECT 1
                FROM users
                WHERE users.id = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NULL
            ) THEN 'active'
            WHEN EXISTS(
                SELECT 1
                FROM users
                WHERE users.id = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NOT NULL
            ) THEN 'soft_deleted'
            ELSE 'not_found' END AS status;

--- a/internal/infrastructure/storage/user/postgres/sqlc/models.go
+++ b/internal/infrastructure/storage/user/postgres/sqlc/models.go
@@ -28,7 +28,6 @@ type ClientStatus struct {
 type Token struct {
 	Token       string    `db:"token"`
 	UserID      string    `db:"user_id"`
-	ClientID    string    `db:"client_id"`
 	Endpoint    string    `db:"endpoint"`
 	Recipient   string    `db:"recipient"`
 	TokenTypeID int32     `db:"token_type_id"`
@@ -45,7 +44,6 @@ type User struct {
 	ID           string             `db:"id"`
 	Email        string             `db:"email"`
 	PasswordHash string             `db:"password_hash"`
-	ClientID     string             `db:"client_id"`
 	Verified     pgtype.Bool        `db:"verified"`
 	CreatedAt    time.Time          `db:"created_at"`
 	UpdatedAt    time.Time          `db:"updated_at"`
@@ -55,7 +53,6 @@ type User struct {
 type UserDevice struct {
 	ID            string             `db:"id"`
 	UserID        string             `db:"user_id"`
-	ClientID      string             `db:"client_id"`
 	UserAgent     string             `db:"user_agent"`
 	Ip            string             `db:"ip"`
 	Detached      bool               `db:"detached"`

--- a/internal/infrastructure/storage/user/postgres/sqlc/querier.go
+++ b/internal/infrastructure/storage/user/postgres/sqlc/querier.go
@@ -10,11 +10,11 @@ import (
 
 type Querier interface {
 	DeleteUser(ctx context.Context, arg DeleteUserParams) error
-	GetUserByEmail(ctx context.Context, arg GetUserByEmailParams) (GetUserByEmailRow, error)
-	GetUserByID(ctx context.Context, arg GetUserByIDParams) (GetUserByIDRow, error)
-	GetUserData(ctx context.Context, arg GetUserDataParams) (GetUserDataRow, error)
-	GetUserStatusByEmail(ctx context.Context, arg GetUserStatusByEmailParams) (string, error)
-	GetUserStatusByID(ctx context.Context, arg GetUserStatusByIDParams) (string, error)
+	GetUserByEmail(ctx context.Context, email string) (GetUserByEmailRow, error)
+	GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error)
+	GetUserData(ctx context.Context, id string) (GetUserDataRow, error)
+	GetUserStatusByEmail(ctx context.Context, email string) (string, error)
+	GetUserStatusByID(ctx context.Context, id string) (string, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/infrastructure/storage/user/postgres/sqlc/user.sql.go
+++ b/internal/infrastructure/storage/user/postgres/sqlc/user.sql.go
@@ -16,81 +16,59 @@ const deleteUser = `-- name: DeleteUser :exec
 UPDATE users
 SET deleted_at = $1
 WHERE id = $2
-  AND client_id = $3
   AND deleted_at IS NULL
 `
 
 type DeleteUserParams struct {
 	DeletedAt pgtype.Timestamptz `db:"deleted_at"`
 	ID        string             `db:"id"`
-	ClientID  string             `db:"client_id"`
 }
 
 func (q *Queries) DeleteUser(ctx context.Context, arg DeleteUserParams) error {
-	_, err := q.db.Exec(ctx, deleteUser, arg.DeletedAt, arg.ID, arg.ClientID)
+	_, err := q.db.Exec(ctx, deleteUser, arg.DeletedAt, arg.ID)
 	return err
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, client_id, updated_at
+SELECT id, email, updated_at
 FROM users
 WHERE email = $1
-  AND client_id = $2
   AND deleted_at IS NULL
 `
-
-type GetUserByEmailParams struct {
-	Email    string `db:"email"`
-	ClientID string `db:"client_id"`
-}
 
 type GetUserByEmailRow struct {
 	ID        string    `db:"id"`
 	Email     string    `db:"email"`
-	ClientID  string    `db:"client_id"`
 	UpdatedAt time.Time `db:"updated_at"`
 }
 
-func (q *Queries) GetUserByEmail(ctx context.Context, arg GetUserByEmailParams) (GetUserByEmailRow, error) {
-	row := q.db.QueryRow(ctx, getUserByEmail, arg.Email, arg.ClientID)
+func (q *Queries) GetUserByEmail(ctx context.Context, email string) (GetUserByEmailRow, error) {
+	row := q.db.QueryRow(ctx, getUserByEmail, email)
 	var i GetUserByEmailRow
-	err := row.Scan(
-		&i.ID,
-		&i.Email,
-		&i.ClientID,
-		&i.UpdatedAt,
-	)
+	err := row.Scan(&i.ID, &i.Email, &i.UpdatedAt)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, client_id, verified, updated_at
+SELECT id, email, verified, updated_at
 FROM users
 WHERE id = $1
-  AND client_id = $2
   AND deleted_at IS NULL
 `
-
-type GetUserByIDParams struct {
-	ID       string `db:"id"`
-	ClientID string `db:"client_id"`
-}
 
 type GetUserByIDRow struct {
 	ID        string      `db:"id"`
 	Email     string      `db:"email"`
-	ClientID  string      `db:"client_id"`
 	Verified  pgtype.Bool `db:"verified"`
 	UpdatedAt time.Time   `db:"updated_at"`
 }
 
-func (q *Queries) GetUserByID(ctx context.Context, arg GetUserByIDParams) (GetUserByIDRow, error) {
-	row := q.db.QueryRow(ctx, getUserByID, arg.ID, arg.ClientID)
+func (q *Queries) GetUserByID(ctx context.Context, id string) (GetUserByIDRow, error) {
+	row := q.db.QueryRow(ctx, getUserByID, id)
 	var i GetUserByIDRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
-		&i.ClientID,
 		&i.Verified,
 		&i.UpdatedAt,
 	)
@@ -98,34 +76,26 @@ func (q *Queries) GetUserByID(ctx context.Context, arg GetUserByIDParams) (GetUs
 }
 
 const getUserData = `-- name: GetUserData :one
-SELECT id, email, password_hash, client_id, updated_at
+SELECT id, email, password_hash, updated_at
 FROM users
 WHERE id = $1
-  AND client_id = $2
   AND deleted_at IS NULL
 `
-
-type GetUserDataParams struct {
-	ID       string `db:"id"`
-	ClientID string `db:"client_id"`
-}
 
 type GetUserDataRow struct {
 	ID           string    `db:"id"`
 	Email        string    `db:"email"`
 	PasswordHash string    `db:"password_hash"`
-	ClientID     string    `db:"client_id"`
 	UpdatedAt    time.Time `db:"updated_at"`
 }
 
-func (q *Queries) GetUserData(ctx context.Context, arg GetUserDataParams) (GetUserDataRow, error) {
-	row := q.db.QueryRow(ctx, getUserData, arg.ID, arg.ClientID)
+func (q *Queries) GetUserData(ctx context.Context, id string) (GetUserDataRow, error) {
+	row := q.db.QueryRow(ctx, getUserData, id)
 	var i GetUserDataRow
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
 		&i.PasswordHash,
-		&i.ClientID,
 		&i.UpdatedAt,
 	)
 	return i, err
@@ -137,26 +107,19 @@ SELECT CASE
                SELECT 1
                FROM users
                WHERE users.email = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NULL
            ) THEN 'active'
            WHEN EXISTS(
                SELECT 1
                FROM users
                WHERE users.email = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NOT NULL
            ) THEN 'soft_deleted'
            ELSE 'not_found' END AS status
 `
 
-type GetUserStatusByEmailParams struct {
-	Email    string `db:"email"`
-	ClientID string `db:"client_id"`
-}
-
-func (q *Queries) GetUserStatusByEmail(ctx context.Context, arg GetUserStatusByEmailParams) (string, error) {
-	row := q.db.QueryRow(ctx, getUserStatusByEmail, arg.Email, arg.ClientID)
+func (q *Queries) GetUserStatusByEmail(ctx context.Context, email string) (string, error) {
+	row := q.db.QueryRow(ctx, getUserStatusByEmail, email)
 	var status string
 	err := row.Scan(&status)
 	return status, err
@@ -168,26 +131,19 @@ SELECT CASE
                SELECT 1
                FROM users
                WHERE users.id = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NULL
            ) THEN 'active'
            WHEN EXISTS(
                SELECT 1
                FROM users
                WHERE users.id = $1
-                 AND users.client_id = $2
                  AND deleted_at IS NOT NULL
            ) THEN 'soft_deleted'
            ELSE 'not_found' END AS status
 `
 
-type GetUserStatusByIDParams struct {
-	ID       string `db:"id"`
-	ClientID string `db:"client_id"`
-}
-
-func (q *Queries) GetUserStatusByID(ctx context.Context, arg GetUserStatusByIDParams) (string, error) {
-	row := q.db.QueryRow(ctx, getUserStatusByID, arg.ID, arg.ClientID)
+func (q *Queries) GetUserStatusByID(ctx context.Context, id string) (string, error) {
+	row := q.db.QueryRow(ctx, getUserStatusByID, id)
 	var status string
 	err := row.Scan(&status)
 	return status, err

--- a/internal/infrastructure/storage/verification/mongo/models.go
+++ b/internal/infrastructure/storage/verification/mongo/models.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	fieldAppID  = "client_id"
 	fieldUserID = "user_id"
 	fieldToken  = "token"
 )
@@ -17,7 +16,6 @@ type tokenDocument struct {
 	ID          primitive.ObjectID `bson:"_id"`
 	Token       string             `bson:"token"`
 	UserID      string             `bson:"user_id"`
-	ClientID    string             `bson:"client_id"`
 	Endpoint    string             `bson:"endpoint"`
 	Recipient   string             `bson:"recipient"`
 	TokenTypeID int32              `bson:"token_type_id"`
@@ -30,7 +28,6 @@ func toTokenDoc(token entity.VerificationToken) tokenDocument {
 		ID:          primitive.NewObjectID(),
 		Token:       token.Token,
 		UserID:      token.UserID,
-		ClientID:    token.ClientID,
 		Endpoint:    token.Endpoint,
 		Recipient:   token.Email,
 		TokenTypeID: int32(token.Type),
@@ -43,7 +40,6 @@ func toVerificationTokenEntity(doc tokenDocument) entity.VerificationToken {
 	return entity.VerificationToken{
 		Token:     doc.Token,
 		UserID:    doc.UserID,
-		ClientID:  doc.ClientID,
 		Endpoint:  doc.Endpoint,
 		Email:     doc.Recipient,
 		Type:      entity.VerificationTokenType(doc.TokenTypeID),

--- a/internal/infrastructure/storage/verification/mongo/verification.go
+++ b/internal/infrastructure/storage/verification/mongo/verification.go
@@ -98,14 +98,13 @@ func (s *VerificationStorage) DeleteVerificationToken(ctx context.Context, token
 	return nil
 }
 
-func (s *VerificationStorage) DeleteAllTokens(ctx context.Context, clientID, userID string) error {
+func (s *VerificationStorage) DeleteAllTokens(ctx context.Context, userID string) error {
 	const method = "storage.verification.mongo.DeleteAllTokens"
 
 	ctx, cancel := context.WithTimeout(ctx, s.timeout)
 	defer cancel()
 
 	filter := bson.M{
-		fieldAppID:  clientID,
 		fieldUserID: userID,
 	}
 

--- a/internal/infrastructure/storage/verification/postgres/query/verification.sql
+++ b/internal/infrastructure/storage/verification/postgres/query/verification.sql
@@ -1,9 +1,9 @@
 -- name: SaveVerificationToken :exec
-INSERT INTO tokens (token, user_id, client_id, endpoint, recipient, token_type_id,  created_at, expires_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
+INSERT INTO tokens (token, user_id, endpoint, recipient, token_type_id,  created_at, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7);
 
 -- name: GetVerificationTokenData :one
-SELECT token, user_id, client_id, endpoint, token_type_id, recipient, expires_at
+SELECT token, user_id, endpoint, token_type_id, recipient, expires_at
 FROM tokens
 WHERE token = $1;
 
@@ -14,5 +14,4 @@ WHERE token = $1;
 
 -- name: DeleteAllVerificationTokens :exec
 DELETE FROM tokens
-WHERE user_id = $1
-  AND client_id = $2;
+WHERE user_id = $1;

--- a/internal/infrastructure/storage/verification/postgres/sqlc/models.go
+++ b/internal/infrastructure/storage/verification/postgres/sqlc/models.go
@@ -28,7 +28,6 @@ type ClientStatus struct {
 type Token struct {
 	Token       string    `db:"token"`
 	UserID      string    `db:"user_id"`
-	ClientID    string    `db:"client_id"`
 	Endpoint    string    `db:"endpoint"`
 	Recipient   string    `db:"recipient"`
 	TokenTypeID int32     `db:"token_type_id"`
@@ -45,7 +44,6 @@ type User struct {
 	ID           string             `db:"id"`
 	Email        string             `db:"email"`
 	PasswordHash string             `db:"password_hash"`
-	ClientID     string             `db:"client_id"`
 	Verified     pgtype.Bool        `db:"verified"`
 	CreatedAt    time.Time          `db:"created_at"`
 	UpdatedAt    time.Time          `db:"updated_at"`
@@ -55,7 +53,6 @@ type User struct {
 type UserDevice struct {
 	ID            string             `db:"id"`
 	UserID        string             `db:"user_id"`
-	ClientID      string             `db:"client_id"`
 	UserAgent     string             `db:"user_agent"`
 	Ip            string             `db:"ip"`
 	Detached      bool               `db:"detached"`

--- a/internal/infrastructure/storage/verification/postgres/sqlc/querier.go
+++ b/internal/infrastructure/storage/verification/postgres/sqlc/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	DeleteAllVerificationTokens(ctx context.Context, arg DeleteAllVerificationTokensParams) error
+	DeleteAllVerificationTokens(ctx context.Context, userID string) error
 	DeleteVerificationToken(ctx context.Context, token string) error
 	GetVerificationTokenData(ctx context.Context, token string) (GetVerificationTokenDataRow, error)
 	SaveVerificationToken(ctx context.Context, arg SaveVerificationTokenParams) error

--- a/internal/infrastructure/storage/verification/postgres/sqlc/verification.sql.go
+++ b/internal/infrastructure/storage/verification/postgres/sqlc/verification.sql.go
@@ -13,16 +13,10 @@ import (
 const deleteAllVerificationTokens = `-- name: DeleteAllVerificationTokens :exec
 DELETE FROM tokens
 WHERE user_id = $1
-  AND client_id = $2
 `
 
-type DeleteAllVerificationTokensParams struct {
-	UserID   string `db:"user_id"`
-	ClientID string `db:"client_id"`
-}
-
-func (q *Queries) DeleteAllVerificationTokens(ctx context.Context, arg DeleteAllVerificationTokensParams) error {
-	_, err := q.db.Exec(ctx, deleteAllVerificationTokens, arg.UserID, arg.ClientID)
+func (q *Queries) DeleteAllVerificationTokens(ctx context.Context, userID string) error {
+	_, err := q.db.Exec(ctx, deleteAllVerificationTokens, userID)
 	return err
 }
 
@@ -37,7 +31,7 @@ func (q *Queries) DeleteVerificationToken(ctx context.Context, token string) err
 }
 
 const getVerificationTokenData = `-- name: GetVerificationTokenData :one
-SELECT token, user_id, client_id, endpoint, token_type_id, recipient, expires_at
+SELECT token, user_id, endpoint, token_type_id, recipient, expires_at
 FROM tokens
 WHERE token = $1
 `
@@ -45,7 +39,6 @@ WHERE token = $1
 type GetVerificationTokenDataRow struct {
 	Token       string    `db:"token"`
 	UserID      string    `db:"user_id"`
-	ClientID    string    `db:"client_id"`
 	Endpoint    string    `db:"endpoint"`
 	TokenTypeID int32     `db:"token_type_id"`
 	Recipient   string    `db:"recipient"`
@@ -58,7 +51,6 @@ func (q *Queries) GetVerificationTokenData(ctx context.Context, token string) (G
 	err := row.Scan(
 		&i.Token,
 		&i.UserID,
-		&i.ClientID,
 		&i.Endpoint,
 		&i.TokenTypeID,
 		&i.Recipient,
@@ -68,14 +60,13 @@ func (q *Queries) GetVerificationTokenData(ctx context.Context, token string) (G
 }
 
 const saveVerificationToken = `-- name: SaveVerificationToken :exec
-INSERT INTO tokens (token, user_id, client_id, endpoint, recipient, token_type_id,  created_at, expires_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO tokens (token, user_id, endpoint, recipient, token_type_id,  created_at, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 type SaveVerificationTokenParams struct {
 	Token       string    `db:"token"`
 	UserID      string    `db:"user_id"`
-	ClientID    string    `db:"client_id"`
 	Endpoint    string    `db:"endpoint"`
 	Recipient   string    `db:"recipient"`
 	TokenTypeID int32     `db:"token_type_id"`
@@ -87,7 +78,6 @@ func (q *Queries) SaveVerificationToken(ctx context.Context, arg SaveVerificatio
 	_, err := q.db.Exec(ctx, saveVerificationToken,
 		arg.Token,
 		arg.UserID,
-		arg.ClientID,
 		arg.Endpoint,
 		arg.Recipient,
 		arg.TokenTypeID,

--- a/internal/infrastructure/storage/verification/postgres/verification.go
+++ b/internal/infrastructure/storage/verification/postgres/verification.go
@@ -37,7 +37,6 @@ func (s *VerificationStorage) SaveVerificationToken(ctx context.Context, data en
 	params := sqlc.SaveVerificationTokenParams{
 		Token:       data.Token,
 		UserID:      data.UserID,
-		ClientID:    data.ClientID,
 		Endpoint:    data.Endpoint,
 		Recipient:   data.Email,
 		TokenTypeID: int32(data.Type),
@@ -76,7 +75,6 @@ func (s *VerificationStorage) GetVerificationTokenData(ctx context.Context, toke
 	return entity.VerificationToken{
 		Token:     tokenData.Token,
 		UserID:    tokenData.UserID,
-		ClientID:  tokenData.ClientID,
 		Endpoint:  tokenData.Endpoint,
 		Email:     tokenData.Recipient,
 		Type:      entity.VerificationTokenType(tokenData.TokenTypeID),
@@ -104,22 +102,17 @@ func (s *VerificationStorage) DeleteVerificationToken(ctx context.Context, token
 	return nil
 }
 
-func (s *VerificationStorage) DeleteAllTokens(ctx context.Context, clientID, userID string) error {
+func (s *VerificationStorage) DeleteAllTokens(ctx context.Context, userID string) error {
 	const method = "storage.verification.postgres.DeleteAllTokens"
-
-	params := sqlc.DeleteAllVerificationTokensParams{
-		UserID:   userID,
-		ClientID: clientID,
-	}
 
 	// Delete verification tokens within transaction
 	err := s.txMgr.ExecWithinTx(ctx, func(tx pgx.Tx) error {
-		return s.queries.WithTx(tx).DeleteAllVerificationTokens(ctx, params)
+		return s.queries.WithTx(tx).DeleteAllVerificationTokens(ctx, userID)
 	})
 
 	if errors.Is(err, transaction.ErrTransactionNotFoundInCtx) {
 		// Delete verification tokens without transaction
-		err = s.queries.DeleteAllVerificationTokens(ctx, params)
+		err = s.queries.DeleteAllVerificationTokens(ctx, userID)
 	}
 
 	if err != nil {

--- a/migrations/000001_init_schema.up.sql
+++ b/migrations/000001_init_schema.up.sql
@@ -1,38 +1,30 @@
-CREATE TABLE IF NOT EXISTS users
-(
+CREATE TABLE IF NOT EXISTS users (
     id            character varying PRIMARY KEY,
-    email         character varying NOT NULL,
+    email         character varying UNIQUE NOT NULL,
     password_hash character varying NOT NULL,
-    client_id        character varying NOT NULL,
-    verified      boolean DEFAULT false,
+    verified      boolean DEFAULT FALSE,
     created_at    timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
     updated_at    timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
     deleted_at    timestamp WITH TIME ZONE DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_active_users ON users (email, client_id) WHERE deleted_at IS NULL;
-
-CREATE TABLE IF NOT EXISTS token_types
-(
+CREATE TABLE IF NOT EXISTS token_types (
     id    int PRIMARY KEY,
     title character varying NOT NULL UNIQUE
 );
 
-CREATE TABLE IF NOT EXISTS tokens
-(
+CREATE TABLE IF NOT EXISTS tokens (
     token         character varying PRIMARY KEY,
     user_id       character varying NOT NULL,
-    client_id        character varying NOT NULL,
     endpoint      character varying NOT NULL,
     recipient     character varying NOT NULL,
     token_type_id int NOT NULL,
     created_at    timestamp WITH TIME ZONE NOT NULL DEFAULT now(),
     expires_at    timestamp WITH TIME ZONE NOT NULL,
-    UNIQUE (token, user_id, token_type_id, client_id)
+    UNIQUE (token, user_id, token_type_id)
 );
 
-CREATE TABLE IF NOT EXISTS clients
-(
+CREATE TABLE IF NOT EXISTS clients (
     id         character varying PRIMARY KEY,
     name       character varying NOT NULL UNIQUE,
     secret     character varying NOT NULL UNIQUE,
@@ -43,17 +35,14 @@ CREATE TABLE IF NOT EXISTS clients
 );
 
 
-CREATE TABLE IF NOT EXISTS client_statuses
-(
+CREATE TABLE IF NOT EXISTS client_statuses (
     id    int PRIMARY KEY,
     title character varying NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS user_devices
-(
+CREATE TABLE IF NOT EXISTS user_devices (
     id              character varying PRIMARY KEY,
     user_id         character varying NOT NULL,
-    client_id          character varying NOT NULL,
     user_agent      character varying NOT NULL,
     ip              character varying NOT NULL,
     detached        boolean NOT NULL,
@@ -61,11 +50,9 @@ CREATE TABLE IF NOT EXISTS user_devices
     detached_at     timestamp WITH TIME ZONE DEFAULT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_user_device ON user_devices (user_id, client_id, user_agent, ip);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_active_users ON users (email) WHERE deleted_at IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_device ON user_devices (user_id, user_agent, ip);
 
-ALTER TABLE users ADD FOREIGN KEY (client_id) REFERENCES clients(id);
 ALTER TABLE tokens ADD FOREIGN KEY (user_id) REFERENCES users(id);
 ALTER TABLE tokens ADD FOREIGN KEY (token_type_id) REFERENCES token_types(id);
-ALTER TABLE tokens ADD FOREIGN KEY (client_id) REFERENCES clients(id);
 ALTER TABLE user_devices ADD FOREIGN KEY (user_id) REFERENCES users(id);
-ALTER TABLE user_devices ADD FOREIGN KEY (client_id) REFERENCES clients(id);


### PR DESCRIPTION
## Summary

This PR removes the `ClientID` field and parameter across the entire codebase to simplify the domain model and reduce redundancy. All references to `ClientID` have been eliminated from models, services, usecases, storage, and tests.

## Key Changes

- Removed `ClientID` field from `User`, `Token`, `UserDevice`, and `UserDocument` structs
- Removed `ClientID` parameter from methods in:
  - **Session Service**
  - **UserData Service**
  - **Verification Service**
  - **Auth & User Usecases**
  - **Mongo & Postgres storage layers**
- Updated SQL queries, Redis session key logic, and unique indexes to reflect the removal
- Introduced `SessionTokens` struct for cleaner session token handling
- Replaced outdated `interface{}` usage with `any` where applicable
- Updated all affected mocks and tests